### PR TITLE
Use jupiter ClassOrderer

### DIFF
--- a/spring-test-smart-context/src/main/java/com/github/seregamorph/testsmartcontext/JUnitPlatformSupport.java
+++ b/spring-test-smart-context/src/main/java/com/github/seregamorph/testsmartcontext/JUnitPlatformSupport.java
@@ -7,12 +7,6 @@ final class JUnitPlatformSupport {
     private static final boolean JUNIT_VINTAGE_ENGINE_PRESENT = isClassPresent(
         "org.junit.vintage.engine.descriptor.RunnerTestDescriptor");
 
-    private static final boolean JUNIT_JUPITER_ENGINE_PRESENT = isClassPresent(
-        "org.junit.jupiter.engine.descriptor.JupiterTestDescriptor");
-
-    private static final boolean JUNIT_TESTNG_ENGINE_PRESENT = isClassPresent(
-        "org.junit.support.testng.engine.ClassDescriptor");
-
     private static final boolean JUNIT4_PRESENT = isClassPresent(
         "org.junit.runner.RunWith");
 
@@ -21,14 +15,6 @@ final class JUnitPlatformSupport {
 
     static boolean isJUnitVintageEnginePresent() {
         return JUNIT_VINTAGE_ENGINE_PRESENT;
-    }
-
-    static boolean isJUnitJupiterEnginePresent() {
-        return JUNIT_JUPITER_ENGINE_PRESENT;
-    }
-
-    static boolean isJUnitTestNGEnginePresent() {
-        return JUNIT_TESTNG_ENGINE_PRESENT;
     }
 
     static boolean isJunit4Present() {

--- a/spring-test-smart-context/src/main/java/com/github/seregamorph/testsmartcontext/SmartDirtiesTestsHolder.java
+++ b/spring-test-smart-context/src/main/java/com/github/seregamorph/testsmartcontext/SmartDirtiesTestsHolder.java
@@ -7,7 +7,7 @@ public class SmartDirtiesTestsHolder {
 
     private static Map<Class<?>, Boolean> lastClassPerConfig;
 
-    static int lastClassPerConfigSize() {
+    public static int lastClassPerConfigSize() {
         return lastClassPerConfig == null ? 0 : lastClassPerConfig.size();
     }
 
@@ -24,7 +24,7 @@ public class SmartDirtiesTestsHolder {
         return isLastClassPerConfig;
     }
 
-    public static void setLastClassPerConfig(Map<Class<?>, Boolean> lastClassPerConfig) {
+    protected static void setLastClassPerConfig(Map<Class<?>, Boolean> lastClassPerConfig) {
         SmartDirtiesTestsHolder.lastClassPerConfig = new LinkedHashMap<>(lastClassPerConfig);
     }
 }

--- a/spring-test-smart-context/src/main/java/com/github/seregamorph/testsmartcontext/jupiter/SmartDirtiesClassOrderer.java
+++ b/spring-test-smart-context/src/main/java/com/github/seregamorph/testsmartcontext/jupiter/SmartDirtiesClassOrderer.java
@@ -1,0 +1,43 @@
+package com.github.seregamorph.testsmartcontext.jupiter;
+
+import com.github.seregamorph.testsmartcontext.SmartDirtiesTestsHolder;
+import com.github.seregamorph.testsmartcontext.SmartDirtiesTestsSorter;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.ClassDescriptor;
+import org.junit.jupiter.api.ClassOrderer;
+import org.junit.jupiter.api.ClassOrdererContext;
+
+public class SmartDirtiesClassOrderer extends SmartDirtiesTestsHolder implements ClassOrderer {
+
+    @Override
+    public void orderClasses(ClassOrdererContext context) {
+        List<? extends ClassDescriptor> classDescriptors = context.getClassDescriptors();
+        if (classDescriptors.isEmpty()) {
+            return;
+        }
+
+        Set<Class<?>> uniqueClasses = classDescriptors.stream()
+            .map(ClassDescriptor::getTestClass)
+            .collect(Collectors.toSet());
+        if (uniqueClasses.size() == 1) {
+            // This filter is executed several times during discover and execute phases and
+            // it's not possible to distinguish them here. Sometimes per single test is sent as argument,
+            // sometimes - the whole suite. If it's a suite more than 1, we can save it and never update.
+            // If it's 1 - we should also distinguish single test execution.
+            if (SmartDirtiesTestsHolder.lastClassPerConfigSize() <= 1) {
+                Class<?> testClass = classDescriptors.get(0).getTestClass();
+                SmartDirtiesTestsHolder.setLastClassPerConfig(Collections.singletonMap(testClass, true));
+            }
+            return;
+        }
+
+        SmartDirtiesTestsSorter sorter = SmartDirtiesTestsSorter.getInstance();
+        Map<Class<?>, Boolean> lastClassPerConfig = sorter.sort(classDescriptors, ClassDescriptor::getTestClass);
+
+        SmartDirtiesTestsHolder.setLastClassPerConfig(lastClassPerConfig);
+    }
+}

--- a/spring-test-smart-context/src/main/java/com/github/seregamorph/testsmartcontext/testng/SmartDirtiesSuiteListener.java
+++ b/spring-test-smart-context/src/main/java/com/github/seregamorph/testsmartcontext/testng/SmartDirtiesSuiteListener.java
@@ -19,7 +19,8 @@ import org.testng.xml.XmlSuite;
  * contexts.
  */
 @SuppressWarnings("CodeBlock2Expr")
-public class SmartDirtiesSuiteListener implements IAlterSuiteListener, IMethodInterceptor {
+public class SmartDirtiesSuiteListener extends SmartDirtiesTestsHolder
+    implements IAlterSuiteListener, IMethodInterceptor {
 
     @Override
     public void alter(List<XmlSuite> suites) {

--- a/spring-test-smart-context/src/main/resources/META-INF/services/org.junit.platform.launcher.PostDiscoveryFilter
+++ b/spring-test-smart-context/src/main/resources/META-INF/services/org.junit.platform.launcher.PostDiscoveryFilter
@@ -1,1 +1,1 @@
-com.github.seregamorph.testsmartcontext.SmartDirtiesDiscoveryFilter
+com.github.seregamorph.testsmartcontext.SmartDirtiesPostDiscoveryFilter

--- a/spring-test-smart-context/src/main/resources/junit-platform.properties
+++ b/spring-test-smart-context/src/main/resources/junit-platform.properties
@@ -1,0 +1,1 @@
+junit.jupiter.testclass.order.default = com.github.seregamorph.testsmartcontext.jupiter.SmartDirtiesClassOrderer


### PR DESCRIPTION
Using standard Jupiter ClassOrderer to order classes. Thanks for the idea to Marc Philipp.
The SmartDirtiesPostDiscoveryFilter (implements PostDiscoveryFilter) is kept for junit4 vintage-engine.

Co-authored-by: Marc Philipp <mail@marcphilipp.de>