### PR TITLE
maven-surefire-cached adoption

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,14 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <extensions>
-    <!--
-    https://docs.gradle.com/develocity/maven-extension/current/
-    This extension is used for maven build optimization and enhanced caching.
-    Config: develocity.xml
-    Use "-Ddevelocity.cache.local.enabled=false" to disable build cache optimizations.
-    -->
     <extension>
-        <groupId>com.gradle</groupId>
-        <artifactId>develocity-maven-extension</artifactId>
-        <version>2.0</version>
+        <!-- https://github.com/seregamorph/maven-surefire-cached -->
+        <groupId>com.github.seregamorph</groupId>
+        <artifactId>surefire-cached-extension</artifactId>
+        <version>0.12</version>
     </extension>
 </extensions>

--- a/.mvn/surefire-cached.json
+++ b/.mvn/surefire-cached.json
@@ -1,0 +1,30 @@
+{
+  "//": "Configuration for Maven surefire-cached-extension",
+  "common": {
+    "inputIgnoredProperties": [
+      "java.version",
+      "os.arch",
+      "os.name"
+    ],
+    "cacheExcludes": [
+    ]
+  },
+  "surefire": {
+    "artifacts": {
+      "surefire-reports": {
+        "includes": [
+          "surefire-reports/TEST-*.xml"
+        ]
+      }
+    }
+  },
+  "failsafe": {
+    "artifacts": {
+      "failsafe-reports": {
+        "includes": [
+          "failsafe-reports/TEST-*.xml"
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
Build locally twice:
```
./mvnw clean install
```

The second time you'll see at the end of the build
```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  6.051 s
[INFO] Finished at: 2025-05-18T16:28:00+02:00
[INFO] ------------------------------------------------------------------------
[INFO] Total test cached results (surefire-cached):
[INFO] EMPTY (1 modules): 0s
[INFO] FROM_CACHE (8 modules): 19s serial time saved
[INFO] Total test cached results (failsafe-cached):
[INFO] EMPTY (8 modules): 0.025s
[INFO] FROM_CACHE (1 modules): 0.909s serial time saved
```

You can find in the local file system build caches in `$HOME/.m2/test-cache/surefire-cached/` and `$HOME/.m2/test-cache/failsafe-cached/` accordingly.