### PR TITLE
Check all @ExtendsWith annotations

### DIFF
--- a/demo/demo-maven-junit-platform-jupiter-boot32/src/test/java/com/github/seregamorph/testsmartcontext/SmartDirtiesJupiterEngineTest.java
+++ b/demo/demo-maven-junit-platform-jupiter-boot32/src/test/java/com/github/seregamorph/testsmartcontext/SmartDirtiesJupiterEngineTest.java
@@ -7,6 +7,7 @@ import static org.junit.platform.engine.discovery.ClassNameFilter.excludeClassNa
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectPackage;
 import static org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.request;
 
+import com.github.seregamorph.testsmartcontext.demo.ExtendWithTest;
 import com.github.seregamorph.testsmartcontext.demo.Integration1Test;
 import com.github.seregamorph.testsmartcontext.demo.Integration2Test;
 import com.github.seregamorph.testsmartcontext.demo.NoBaseClass1IntegrationTest;
@@ -25,24 +26,26 @@ public class SmartDirtiesJupiterEngineTest {
                 .build())
             .containerEvents();
 
-        // 8 = 5 ITs + 2 UTs + 1 suite
+        // 8 = 6 ITs + 2 UTs + 1 suite
         events.assertStatistics(stats -> stats
-            .started(8)
-            .succeeded(8)
-            .finished(8)
+            .started(9)
+            .succeeded(9)
+            .finished(9)
             .aborted(0)
             .failed(0));
 
-        assertEquals(5, SmartDirtiesTestsHolder.classOrderStateMapSize());
+        assertEquals(6, SmartDirtiesTestsHolder.classOrderStateMapSize());
 
         assertTrue(SmartDirtiesTestsHolder.isFirstClassPerConfig(Integration1Test.class));
         assertTrue(SmartDirtiesTestsHolder.isFirstClassPerConfig(Integration2Test.class));
-        assertTrue(SmartDirtiesTestsHolder.isFirstClassPerConfig(NoBaseClass1IntegrationTest.class));
+        assertTrue(SmartDirtiesTestsHolder.isFirstClassPerConfig(ExtendWithTest.class));
+        assertFalse(SmartDirtiesTestsHolder.isFirstClassPerConfig(NoBaseClass1IntegrationTest.class));
         assertFalse(SmartDirtiesTestsHolder.isFirstClassPerConfig(NoBaseClass2IntegrationTest.class));
         assertTrue(SmartDirtiesTestsHolder.isFirstClassPerConfig(SampleIntegrationTest.class));
 
         assertTrue(SmartDirtiesTestsHolder.isLastClassPerConfig(Integration1Test.class));
         assertTrue(SmartDirtiesTestsHolder.isLastClassPerConfig(Integration2Test.class));
+        assertFalse(SmartDirtiesTestsHolder.isLastClassPerConfig(ExtendWithTest.class));
         assertFalse(SmartDirtiesTestsHolder.isLastClassPerConfig(NoBaseClass1IntegrationTest.class));
         assertTrue(SmartDirtiesTestsHolder.isLastClassPerConfig(NoBaseClass2IntegrationTest.class));
         assertTrue(SmartDirtiesTestsHolder.isLastClassPerConfig(SampleIntegrationTest.class));

--- a/demo/demo-maven-junit-platform-jupiter-boot32/src/test/java/com/github/seregamorph/testsmartcontext/demo/ExtendWithTest.java
+++ b/demo/demo-maven-junit-platform-jupiter-boot32/src/test/java/com/github/seregamorph/testsmartcontext/demo/ExtendWithTest.java
@@ -1,0 +1,14 @@
+package com.github.seregamorph.testsmartcontext.demo;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+
+@SpringBootTest(classes = SampleIntegrationTest.Configuration.class)
+@ExtendWith(OutputCaptureExtension.class)
+public class ExtendWithTest {
+    @Test
+    public void test() {
+    }
+}

--- a/spring-test-smart-context/src/main/java/com/github/seregamorph/testsmartcontext/SmartDirtiesTestsSorter.java
+++ b/spring-test-smart-context/src/main/java/com/github/seregamorph/testsmartcontext/SmartDirtiesTestsSorter.java
@@ -6,6 +6,7 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -180,12 +181,12 @@ public class SmartDirtiesTestsSorter {
      */
     protected boolean isReorderTestJUnit5Jupiter(Class<?> testClass) {
         // can be inherited, can be meta-annotation e.g. via @SpringBootTest
-        ExtendWith extendWith = AnnotatedElementUtils.findMergedAnnotation(testClass, ExtendWith.class);
-        if (extendWith == null) {
+        Set<ExtendWith> extendWith = AnnotatedElementUtils.findAllMergedAnnotations(testClass, ExtendWith.class);
+        if (extendWith.isEmpty()) {
             return false;
         }
-        Class<? extends Extension>[] extensions = extendWith.value();
-        return Stream.of(extensions)
+
+        return extendWith.stream().map(ExtendWith::value).flatMap(Arrays::stream)
             .anyMatch(SpringExtension.class::isAssignableFrom);
     }
 


### PR DESCRIPTION
This PR fixes handling of `@ExtendsWith` on test classes when other annotations are present that are meta-annotated with `@ExtendsWith` by inspecting all Annotations and not just the first.

```
java.lang.IllegalStateException: classOrderStateMap is not defined for class class com.github.seregamorph.testsmartcontext.demo.ExtendWithTest, it means that it was skipped on initial analysis. Discovered classes: [class com.github.seregamorph.testsmartcontext.demo.Integration1Test, class com.github.seregamorph.testsmartcontext.demo.Integration2Test, class com.github.seregamorph.testsmartcontext.demo.NoBaseClass1IntegrationTest, class com.github.seregamorph.testsmartcontext.demo.NoBaseClass2IntegrationTest, class com.github.seregamorph.testsmartcontext.demo.SampleIntegrationTest]

	at com.github.seregamorph.testsmartcontext.SmartDirtiesTestsHolder.getOrderState(SmartDirtiesTestsHolder.java:57)
	at com.github.seregamorph.testsmartcontext.SmartDirtiesTestsHolder.isLastClassPerConfig(SmartDirtiesTestsHolder.java:33)
	at com.github.seregamorph.testsmartcontext.SmartDirtiesContextTestExecutionListener.afterTestClass(SmartDirtiesContextTestExecutionListener.java:36)
	at org.springframework.test.context.TestContextManager.afterTestClass(TestContextManager.java:538)
	at org.springframework.test.context.junit.jupiter.SpringExtension.afterAll(SpringExtension.java:144)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1597)
```

Fixes #7 