### PR TITLE
Simplified support JUnit @Nested classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ Public presentation with AtomicJar (TestContainers creators):
 ### Limitations
 At the moment only single thread test execution per module is supported. Parallel test execution is work in progress.
 Also there can be problems with Jupiter
-[Nested](https://junit.org/junit5/docs/current/user-guide/#writing-tests-nested) test classes.
+[Nested](https://junit.org/junit5/docs/current/user-guide/#writing-tests-nested) test classes if they declare
+own `@ContextConfiguration` or `@Import` of spring beans.
 
 ### Supported versions
 `Java` 8+ (`Java` 17+ for spring-boot 3.x projects)

--- a/demo/demo-gradle-junit-platform-jupiter-boot32/src/test/java/com/github/seregamorph/testsmartcontext/demo/Integration1Test.java
+++ b/demo/demo-gradle-junit-platform-jupiter-boot32/src/test/java/com/github/seregamorph/testsmartcontext/demo/Integration1Test.java
@@ -1,5 +1,6 @@
 package com.github.seregamorph.testsmartcontext.demo;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
@@ -18,6 +19,18 @@ public class Integration1Test extends AbstractIntegrationTest {
     @Test
     public void test() {
         System.out.println("Integration1Test.test " + rootBean);
+    }
+
+    @Nested
+    public class NestedTest {
+
+        @Autowired
+        private SampleBean nestedBean;
+
+        @Test
+        public void nested() {
+            System.out.println("Integration1Test.NestedTest.test " + nestedBean);
+        }
     }
 
     @Import(SampleBean.class)

--- a/demo/demo-gradle-junit-platform-jupiter-boot32/src/test/java/com/github/seregamorph/testsmartcontext/demo/Integration2Test.java
+++ b/demo/demo-gradle-junit-platform-jupiter-boot32/src/test/java/com/github/seregamorph/testsmartcontext/demo/Integration2Test.java
@@ -1,5 +1,6 @@
 package com.github.seregamorph.testsmartcontext.demo;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ContextConfiguration;
 
@@ -11,6 +12,15 @@ public class Integration2Test extends AbstractIntegrationTest {
     @Test
     public void test() {
         System.out.println("Integration2Test.test");
+    }
+
+    @Nested
+    public class NestedTest {
+
+        @Test
+        public void nested() {
+            System.out.println("Integration2Test.NestedTest.test");
+        }
     }
 
     public static class Configuration {

--- a/demo/demo-maven-junit-platform-jupiter-boot34/src/test/java/com/github/seregamorph/testsmartcontext/SmartDirtiesJupiterEngineTest.java
+++ b/demo/demo-maven-junit-platform-jupiter-boot34/src/test/java/com/github/seregamorph/testsmartcontext/SmartDirtiesJupiterEngineTest.java
@@ -35,15 +35,17 @@ public class SmartDirtiesJupiterEngineTest {
 
         // 10 = 7 ITs + 2 UTs + 1 suite
         events.assertStatistics(stats -> stats
-            .started(11)
-            .succeeded(11)
-            .finished(11)
+            .started(14)
+            .succeeded(14)
+            .finished(14)
             .aborted(0)
             .failed(0));
 
         assertEquals(8, SmartDirtiesTestsHolder.classOrderStateMapSize());
 
         assertTrue(SmartDirtiesTestsHolder.isFirstClassPerConfig(Integration1Test.class));
+        assertFalse(SmartDirtiesTestsHolder.isFirstClassPerConfig(Integration1Test.NestedTest.class));
+        assertFalse(SmartDirtiesTestsHolder.isFirstClassPerConfig(Integration1Test.NestedTest.DeeplyNestedTest.class));
         assertTrue(SmartDirtiesTestsHolder.isFirstClassPerConfig(Integration2Test.class));
         assertFalse(SmartDirtiesTestsHolder.isFirstClassPerConfig(ExtendWithTest.class));
         assertFalse(SmartDirtiesTestsHolder.isFirstClassPerConfig(NoBaseClass1IntegrationTest.class));
@@ -52,6 +54,8 @@ public class SmartDirtiesJupiterEngineTest {
         assertFalse(SmartDirtiesTestsHolder.isFirstClassPerConfig(SampleDirtiesContextAfterClassTest.class));
         assertTrue(SmartDirtiesTestsHolder.isFirstClassPerConfig(SampleIntegrationTest.class));
 
+        assertFalse(SmartDirtiesTestsHolder.isLastClassPerConfig(Integration1Test.NestedTest.DeeplyNestedTest.class));
+        assertFalse(SmartDirtiesTestsHolder.isLastClassPerConfig(Integration1Test.NestedTest.class));
         assertTrue(SmartDirtiesTestsHolder.isLastClassPerConfig(Integration1Test.class));
         assertTrue(SmartDirtiesTestsHolder.isLastClassPerConfig(Integration2Test.class));
         assertFalse(SmartDirtiesTestsHolder.isLastClassPerConfig(ExtendWithTest.class));

--- a/demo/demo-maven-junit-platform-jupiter-boot34/src/test/java/com/github/seregamorph/testsmartcontext/SmartDirtiesTestsHolderTest.java
+++ b/demo/demo-maven-junit-platform-jupiter-boot34/src/test/java/com/github/seregamorph/testsmartcontext/SmartDirtiesTestsHolderTest.java
@@ -1,0 +1,49 @@
+package com.github.seregamorph.testsmartcontext;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+
+class SmartDirtiesTestsHolderTest {
+
+    @Test
+    public void nestedInheritShouldPass() {
+        SmartDirtiesTestsHolder.verifyInnerClass(TestRootTest.NestedInheritTest.class);
+    }
+
+    @Test
+    public void nestedCustomShouldFail() {
+        var ise = Assertions.assertThrows(IllegalStateException.class,
+            () -> SmartDirtiesTestsHolder.verifyInnerClass(TestRootTest.NestedCustomTest.class));
+        assertEquals("Nested inner class com.github.seregamorph.testsmartcontext.TestRootTest$NestedCustomTest " +
+            "declares custom context configuration which differs from enclosing class com.github.seregamorph" +
+            ".testsmartcontext.TestRootTest. This is not properly supported by the spring-test-smart-context ordering" +
+            " because of framework limitations. Please extract inner test class to upper level.", ise.getMessage());
+    }
+}
+
+@ContextConfiguration(classes = {
+    TestRootTest.Configuration.class
+})
+class TestRootTest {
+
+    public static class Configuration {
+
+    }
+
+    @Nested
+    public class NestedInheritTest {
+    }
+
+    @Nested
+    @TestPropertySource(properties = {
+        "parameter = value"
+    })
+    public class NestedCustomTest {
+
+    }
+}

--- a/demo/demo-maven-junit-platform-jupiter-boot34/src/test/java/com/github/seregamorph/testsmartcontext/demo/Integration1Test.java
+++ b/demo/demo-maven-junit-platform-jupiter-boot34/src/test/java/com/github/seregamorph/testsmartcontext/demo/Integration1Test.java
@@ -1,5 +1,6 @@
 package com.github.seregamorph.testsmartcontext.demo;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
@@ -18,6 +19,30 @@ public class Integration1Test extends AbstractIntegrationTest {
     @Test
     public void test() {
         System.out.println("Integration1Test.test " + rootBean);
+    }
+
+    @Nested
+    public class NestedTest {
+
+        @Autowired
+        private SampleBean nestedBean;
+
+        @Test
+        public void nested() {
+            System.out.println("Integration1Test.NestedTest.test " + nestedBean);
+        }
+
+        @Nested
+        public class DeeplyNestedTest {
+
+            @Autowired
+            private SampleBean deeplyNestedBean;
+
+            @Test
+            public void deeplyNested() {
+                System.out.println("Integration1Test.NestedTest.DeeplyNestedTest.deeplyNested " + deeplyNestedBean);
+            }
+        }
     }
 
     @Import(SampleBean.class)

--- a/demo/demo-maven-junit-platform-jupiter-boot34/src/test/java/com/github/seregamorph/testsmartcontext/demo/Integration2Test.java
+++ b/demo/demo-maven-junit-platform-jupiter-boot34/src/test/java/com/github/seregamorph/testsmartcontext/demo/Integration2Test.java
@@ -1,5 +1,6 @@
 package com.github.seregamorph.testsmartcontext.demo;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ContextConfiguration;
 
@@ -11,6 +12,15 @@ public class Integration2Test extends AbstractIntegrationTest {
     @Test
     public void test() {
         System.out.println("Integration2Test.test");
+    }
+
+    @Nested
+    public class NestedTest {
+
+        @Test
+        public void nested() {
+            System.out.println("Integration2Test.NestedTest.test");
+        }
     }
 
     public static class Configuration {

--- a/spring-test-smart-context/src/main/java/com/github/seregamorph/testsmartcontext/SmartDirtiesContextTestExecutionListener.java
+++ b/spring-test-smart-context/src/main/java/com/github/seregamorph/testsmartcontext/SmartDirtiesContextTestExecutionListener.java
@@ -1,5 +1,7 @@
 package com.github.seregamorph.testsmartcontext;
 
+import static com.github.seregamorph.testsmartcontext.SmartDirtiesTestsHolder.isInnerClass;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.test.context.TestContext;
@@ -28,6 +30,14 @@ public class SmartDirtiesContextTestExecutionListener extends AbstractTestExecut
         // DirtiesContextTestExecutionListener.getOrder() + 1
         //noinspection MagicNumber
         return 3001;
+    }
+
+    @Override
+    public void beforeTestClass(TestContext testContext) {
+        Class<?> testClass = testContext.getTestClass();
+        if (isInnerClass(testClass)) {
+            SmartDirtiesTestsHolder.verifyInnerClass(testClass);
+        }
     }
 
     @Override

--- a/spring-test-smart-context/src/main/java/com/github/seregamorph/testsmartcontext/jupiter/SmartDirtiesClassOrderer.java
+++ b/spring-test-smart-context/src/main/java/com/github/seregamorph/testsmartcontext/jupiter/SmartDirtiesClassOrderer.java
@@ -4,12 +4,14 @@ import static java.util.Collections.singletonList;
 
 import com.github.seregamorph.testsmartcontext.SmartDirtiesTestsHolder;
 import com.github.seregamorph.testsmartcontext.SmartDirtiesTestsSorter;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.junit.jupiter.api.ClassDescriptor;
 import org.junit.jupiter.api.ClassOrderer;
 import org.junit.jupiter.api.ClassOrdererContext;
+import org.junit.jupiter.api.Nested;
+import org.springframework.core.annotation.AnnotationUtils;
 
 /**
  * Auto-discovered Jupiter {@link ClassOrderer} which reorders and groups the integration test classes per their
@@ -28,9 +30,47 @@ public class SmartDirtiesClassOrderer extends SmartDirtiesTestsHolder implements
             return;
         }
 
-        Set<Class<?>> uniqueClasses = classDescriptors.stream()
-            .map(ClassDescriptor::getTestClass)
-            .collect(Collectors.toSet());
+        // Special notes: Maven has different behavior in comparison with IDEA and Gradle, it calls orderClasses method
+        // for each test class with a single element of classDescriptors list. That's why we need to handle single-size
+        // list separately.
+
+        // If Jupiter Test class has @Nested inner classes, for each of them (if there is only one inner class)
+        // orderClasses will be called
+
+        Set<Class<?>> uniqueClasses = new LinkedHashSet<>();
+        for (ClassDescriptor classDescriptor : classDescriptors) {
+            Class<?> testClass = classDescriptor.getTestClass();
+            if (isInnerClass(testClass)) {
+                if (!uniqueClasses.isEmpty()) {
+                    // this should not happen, they should be never mixed in one call
+                    throw new IllegalStateException("Unexpected mix of inner " + testClass + " and " + uniqueClasses);
+                }
+                Nested nested = AnnotationUtils.getAnnotation(testClass, Nested.class);
+                if (nested == null) {
+                    // this should not happen
+                    throw new IllegalStateException("Missing @Nested annotation for inner " + testClass);
+                }
+                // implementation notice: if the exception is thrown from this block, it does not break the
+                // test execution as it's suppressed in
+                // org.junit.jupiter.engine.discovery.AbstractOrderingVisitor.doWithMatchingDescriptor
+                // So this validation will be repeated at BeforeClass
+                verifyInnerClass(testClass);
+            } else {
+                // regular test class
+                uniqueClasses.add(testClass);
+            }
+        }
+
+        if (uniqueClasses.isEmpty()) {
+            // All are internal (@Nested), we do not reorder them.
+            // The enclosing classes are already in the SmartDirtiesTestsHolder from previous call
+            if (SmartDirtiesTestsHolder.classOrderStateMapSize() == 0) {
+                throw new IllegalStateException("orderClasses is called with inner classes list " + classDescriptors
+                  + " before being called with enclosing class list");
+            }
+            return;
+        }
+
         if (uniqueClasses.size() == 1) {
             // This filter is executed several times during discover and execute phases and
             // it's not possible to distinguish them here. Sometimes per single test is sent as argument,


### PR DESCRIPTION
In case if JUnit Jupiter Test class has `@Nested` classes, there can be failures:
```
ClinicServiceTests > executionError FAILED
    java.lang.IllegalStateException: classOrderStateMap is not defined for class class org.springframework.samples.petclinic.service.ClinicServiceTests, it means that it was skipped on initial analysis. Discovered classes: []
        at com.github.seregamorph.testsmartcontext.SmartDirtiesTestsHolder.getOrderState(SmartDirtiesTestsHolder.java:57)
        at com.github.seregamorph.testsmartcontext.SmartDirtiesTestsHolder.isLastClassPerConfig(SmartDirtiesTestsHolder.java:33)
        at com.github.seregamorph.testsmartcontext.SmartDirtiesContextTestExecutionListener.afterTestClass(SmartDirtiesContextTestExecutionListener.java:36)
        at org.springframework.test.context.TestContextManager.afterTestClass(TestContextManager.java:538)
        at org.springframework.test.context.junit.jupiter.SpringExtension.afterAll(SpringExtension.java:141)
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
```

In this PR the simplified `@Nested` Jupiter test support is introduced. If `@Nested` class does not have it's own configuration declared via `@ContextConfiguration`, `@Import` and other annotations (and hence inherit enclosing class configuration), it will be executed. Otherwise the proper diagnostics is thrown.

Known disadvantages of the solution:
* the test sorter can throw an exception, but it's suppressed by JUnit Platform framework. So there is no fail-fast, the `@Nested` test with custom configuration will fail only on its execution.