### PR TITLE
Sort @DirtiesContext Test classes to the end of their group

### DIFF
--- a/demo/demo-maven-junit-platform-jupiter-boot32/src/test/java/com/github/seregamorph/testsmartcontext/SmartDirtiesJupiterEngineTest.java
+++ b/demo/demo-maven-junit-platform-jupiter-boot32/src/test/java/com/github/seregamorph/testsmartcontext/SmartDirtiesJupiterEngineTest.java
@@ -7,6 +7,7 @@ import static org.junit.platform.engine.discovery.ClassNameFilter.excludeClassNa
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectPackage;
 import static org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.request;
 
+import com.github.seregamorph.testsmartcontext.demo.DirtiesContextTest;
 import com.github.seregamorph.testsmartcontext.demo.ExtendWithTest;
 import com.github.seregamorph.testsmartcontext.demo.Integration1Test;
 import com.github.seregamorph.testsmartcontext.demo.Integration2Test;
@@ -26,28 +27,30 @@ public class SmartDirtiesJupiterEngineTest {
                 .build())
             .containerEvents();
 
-        // 8 = 6 ITs + 2 UTs + 1 suite
+        // 10 = 7 ITs + 2 UTs + 1 suite
         events.assertStatistics(stats -> stats
-            .started(9)
-            .succeeded(9)
-            .finished(9)
+            .started(10)
+            .succeeded(10)
+            .finished(10)
             .aborted(0)
             .failed(0));
 
-        assertEquals(6, SmartDirtiesTestsHolder.classOrderStateMapSize());
+        assertEquals(7, SmartDirtiesTestsHolder.classOrderStateMapSize());
 
         assertTrue(SmartDirtiesTestsHolder.isFirstClassPerConfig(Integration1Test.class));
         assertTrue(SmartDirtiesTestsHolder.isFirstClassPerConfig(Integration2Test.class));
         assertTrue(SmartDirtiesTestsHolder.isFirstClassPerConfig(ExtendWithTest.class));
         assertFalse(SmartDirtiesTestsHolder.isFirstClassPerConfig(NoBaseClass1IntegrationTest.class));
         assertFalse(SmartDirtiesTestsHolder.isFirstClassPerConfig(NoBaseClass2IntegrationTest.class));
+        assertFalse(SmartDirtiesTestsHolder.isFirstClassPerConfig(DirtiesContextTest.class));
         assertTrue(SmartDirtiesTestsHolder.isFirstClassPerConfig(SampleIntegrationTest.class));
 
         assertTrue(SmartDirtiesTestsHolder.isLastClassPerConfig(Integration1Test.class));
         assertTrue(SmartDirtiesTestsHolder.isLastClassPerConfig(Integration2Test.class));
         assertFalse(SmartDirtiesTestsHolder.isLastClassPerConfig(ExtendWithTest.class));
         assertFalse(SmartDirtiesTestsHolder.isLastClassPerConfig(NoBaseClass1IntegrationTest.class));
-        assertTrue(SmartDirtiesTestsHolder.isLastClassPerConfig(NoBaseClass2IntegrationTest.class));
+        assertFalse(SmartDirtiesTestsHolder.isLastClassPerConfig(NoBaseClass2IntegrationTest.class));
+        assertTrue(SmartDirtiesTestsHolder.isLastClassPerConfig(DirtiesContextTest.class));
         assertTrue(SmartDirtiesTestsHolder.isLastClassPerConfig(SampleIntegrationTest.class));
     }
 }

--- a/demo/demo-maven-junit-platform-jupiter-boot32/src/test/java/com/github/seregamorph/testsmartcontext/demo/DirtiesContextTest.java
+++ b/demo/demo-maven-junit-platform-jupiter-boot32/src/test/java/com/github/seregamorph/testsmartcontext/demo/DirtiesContextTest.java
@@ -1,0 +1,13 @@
+package com.github.seregamorph.testsmartcontext.demo;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+
+@SpringBootTest(classes = SampleIntegrationTest.Configuration.class)
+@DirtiesContext
+public class DirtiesContextTest {
+    @Test
+    public void test() {
+    }
+}

--- a/demo/demo-maven-junit-platform-jupiter-boot32/src/test/java/com/github/seregamorph/testsmartcontext/demo/SmartDirtiesJupiterTestsSorterTest.java
+++ b/demo/demo-maven-junit-platform-jupiter-boot32/src/test/java/com/github/seregamorph/testsmartcontext/demo/SmartDirtiesJupiterTestsSorterTest.java
@@ -10,40 +10,46 @@ import org.junit.jupiter.api.Test;
 public class SmartDirtiesJupiterTestsSorterTest {
 
     @Test
-    public void shouldSortAlphabeticallyAndGroupSameConfigurations() {
+    public void shouldSortMostlyAlphabeticallyAndGroupSameConfigurations() {
+        // mostly: @DirtiesContext should go last.
         SmartDirtiesTestsSorter sorter = SmartDirtiesTestsSorter.getInstance();
-        System.out.println(">>>shouldSortAlphabeticallyAndGroupSameConfigurations>>>");
+        System.out.println(">>>shouldSortMostlyAlphabeticallyAndGroupSameConfigurations>>>");
         var testItems = Arrays.asList(
             Integration2Test.class,
             SampleIntegrationTest.class,
             Integration1Test.class,
             Unit1Test.class,
+            DirtiesContextTest.class,
             NoBaseClass2IntegrationTest.class,
             NoBaseClass1IntegrationTest.class,
+            ExtendWithTest.class,
             SmartDirtiesJupiterTestsSorterTest.class
         );
         var itClassesLists = sorter.sort(testItems, testClass -> testClass);
-        System.out.println("<<<shouldSortAlphabeticallyAndGroupSameConfigurations<<<");
+        System.out.println("<<<shouldSortMostlyAlphabeticallyAndGroupSameConfigurations<<<");
 
         assertEquals(Arrays.asList(
             // UT
             SmartDirtiesJupiterTestsSorterTest.class,
             Unit1Test.class,
             // IT 1
-            Integration1Test.class,
-            // IT 2
-            Integration2Test.class,
-            // IT 3
+            ExtendWithTest.class,
             NoBaseClass1IntegrationTest.class,
             NoBaseClass2IntegrationTest.class,
+            DirtiesContextTest.class,
+            // IT 2
+            Integration1Test.class,
+            // IT 3
+            Integration2Test.class,
             // IT 4
             SampleIntegrationTest.class
         ), testItems);
 
         assertEquals(List.of(
+            List.of(ExtendWithTest.class, NoBaseClass1IntegrationTest.class, NoBaseClass2IntegrationTest.class,
+                DirtiesContextTest.class),
             List.of(Integration1Test.class),
             List.of(Integration2Test.class),
-            List.of(NoBaseClass1IntegrationTest.class, NoBaseClass2IntegrationTest.class),
             List.of(SampleIntegrationTest.class)
         ), itClassesLists);
     }


### PR DESCRIPTION
This PR slightly changes how test classes are sorted inside their group: Classes annotated with `@DirtiesContext` (with `classMode = DirtiesContext.ClassMode.AFTER_CLASS`) are executed after non-annotated classes.
This allows up to one `@DirtiesContext` per group without impacting number of created or stopped spring application contexts.  
Multiple annotated classes will still cause extra application context stops and starts. If no class is annotated nothing changes.