### PR TITLE
Support mixed JUnit platform engines in one module

### DIFF
--- a/demo/demo-maven-junit-platform-junit4-boot24/src/test/java/com/github/seregamorph/testsmartcontext/MavenSmartDirtiesVintageEngineTest.java
+++ b/demo/demo-maven-junit-platform-junit4-boot24/src/test/java/com/github/seregamorph/testsmartcontext/MavenSmartDirtiesVintageEngineTest.java
@@ -33,7 +33,7 @@ public class MavenSmartDirtiesVintageEngineTest {
         // to avoid confusion of duplicated test execution output
         System.out.println(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>");
         System.out.println(">>>EngineTestKit duplicating the suite>>>");
-        SmartDirtiesTestsHolder.reset();
+        SmartDirtiesTestsHolder.reset(ENGINE);
 
         var events = EngineTestKit.execute(ENGINE, request()
                 .selectors(selectPackage("com.github.seregamorph.testsmartcontext.demo"))
@@ -49,7 +49,7 @@ public class MavenSmartDirtiesVintageEngineTest {
             .aborted(0)
             .failed(0));
 
-        assertEquals(3, SmartDirtiesTestsHolder.classOrderStateMapSize());
+        assertEquals(3, SmartDirtiesTestsHolder.classOrderStateMapSize(ENGINE));
 
         assertTrue(SmartDirtiesTestsHolder.isFirstClassPerConfig(Integration1Test.class));
         assertTrue(SmartDirtiesTestsHolder.isFirstClassPerConfig(Integration2Test.class));

--- a/demo/demo-maven-junit-platform-jupiter-boot34/src/test/java/com/github/seregamorph/testsmartcontext/MavenSmartDirtiesJupiterEngineTest.java
+++ b/demo/demo-maven-junit-platform-jupiter-boot34/src/test/java/com/github/seregamorph/testsmartcontext/MavenSmartDirtiesJupiterEngineTest.java
@@ -23,6 +23,8 @@ import org.junit.platform.testkit.engine.EngineTestKit;
 
 public class MavenSmartDirtiesJupiterEngineTest {
 
+    private static final String ENGINE = "junit-jupiter";
+
     @BeforeEach
     public void before() {
         TestEventTracker.startTracking();
@@ -38,9 +40,9 @@ public class MavenSmartDirtiesJupiterEngineTest {
         // to avoid confusion of duplicated test execution output
         System.out.println(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>");
         System.out.println(">>>EngineTestKit duplicating the suite>>>");
-        SmartDirtiesTestsHolder.reset();
+        SmartDirtiesTestsHolder.reset(ENGINE);
 
-        var events = EngineTestKit.execute("junit-jupiter", request()
+        var events = EngineTestKit.execute(ENGINE, request()
                 .selectors(selectPackage("com.github.seregamorph.testsmartcontext.demo"))
                 .build())
             .containerEvents();
@@ -53,7 +55,7 @@ public class MavenSmartDirtiesJupiterEngineTest {
             .aborted(0)
             .failed(0));
 
-        assertEquals(9, SmartDirtiesTestsHolder.classOrderStateMapSize());
+        assertEquals(9, SmartDirtiesTestsHolder.classOrderStateMapSize(ENGINE));
 
         assertTrue(SmartDirtiesTestsHolder.isFirstClassPerConfig(Integration1Test.class));
         assertFalse(SmartDirtiesTestsHolder.isFirstClassPerConfig(Integration1Test.NestedTest.class));

--- a/demo/demo-maven-junit-platform-jupiter-spring5/src/test/java/com/github/seregamorph/testsmartcontext/MavenSmartDirtiesJupiterEngineTest.java
+++ b/demo/demo-maven-junit-platform-jupiter-spring5/src/test/java/com/github/seregamorph/testsmartcontext/MavenSmartDirtiesJupiterEngineTest.java
@@ -19,6 +19,8 @@ import org.junit.platform.testkit.engine.EngineTestKit;
 
 public class MavenSmartDirtiesJupiterEngineTest {
 
+    private static final String ENGINE = "junit-jupiter";
+
     @BeforeEach
     public void before() {
         TestEventTracker.startTracking();
@@ -34,9 +36,9 @@ public class MavenSmartDirtiesJupiterEngineTest {
         // to avoid confusion of duplicated test execution output
         System.out.println(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>");
         System.out.println(">>>EngineTestKit duplicating the suite>>>");
-        SmartDirtiesTestsHolder.reset();
+        SmartDirtiesTestsHolder.reset(ENGINE);
 
-        var events = EngineTestKit.execute("junit-jupiter", request()
+        var events = EngineTestKit.execute(ENGINE, request()
                 .selectors(selectPackage("com.github.seregamorph.testsmartcontext.demo"))
                 .build())
             .containerEvents();
@@ -49,7 +51,7 @@ public class MavenSmartDirtiesJupiterEngineTest {
             .aborted(0)
             .failed(0));
 
-        assertEquals(5, SmartDirtiesTestsHolder.classOrderStateMapSize());
+        assertEquals(5, SmartDirtiesTestsHolder.classOrderStateMapSize(ENGINE));
 
         assertTrue(SmartDirtiesTestsHolder.isFirstClassPerConfig(Integration1Test.class));
         assertFalse(SmartDirtiesTestsHolder.isFirstClassPerConfig(Integration1Test.NestedTest.class));

--- a/demo/demo-maven-junit-platform-mixed-boot34/pom.xml
+++ b/demo/demo-maven-junit-platform-mixed-boot34/pom.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.github.seregamorph</groupId>
+        <artifactId>demo-parent</artifactId>
+        <version>0.8-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>demo-maven-junit-platform-mixed-boot34</artifactId>
+
+    <description>Demo project with mixed tests JUnit 4, JUnit 5 and TestNG
+        launched via Maven junit-platform jupiter</description>
+
+    <properties>
+        <spring-boot.version>3.4.1</spring-boot.version>
+        <testng-engine.version>1.0.5</testng-engine.version>
+        <maven.install.skip>true</maven.install.skip>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-junit-platform</artifactId>
+                        <version>${maven-surefire.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring-boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <!--test-->
+        <dependency>
+            <groupId>com.github.seregamorph</groupId>
+            <artifactId>spring-test-smart-context</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.seregamorph</groupId>
+            <artifactId>demo-testkit</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-testkit</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.support</groupId>
+            <artifactId>testng-engine</artifactId>
+            <version>${testng-engine.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/demo/demo-maven-junit-platform-mixed-boot34/src/test/java/com/github/seregamorph/testsmartcontext/MavenSmartDirtiesJupiterEngineTest.java
+++ b/demo/demo-maven-junit-platform-mixed-boot34/src/test/java/com/github/seregamorph/testsmartcontext/MavenSmartDirtiesJupiterEngineTest.java
@@ -1,0 +1,80 @@
+package com.github.seregamorph.testsmartcontext;
+
+import com.github.seregamorph.testsmartcontext.demo.*;
+import com.github.seregamorph.testsmartcontext.testkit.TestEventTracker;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.testkit.engine.EngineTestKit;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.platform.engine.discovery.ClassNameFilter.excludeClassNamePatterns;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectPackage;
+import static org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.request;
+
+public class MavenSmartDirtiesJupiterEngineTest {
+
+    private static final String ENGINE = "junit-jupiter";
+
+    @BeforeEach
+    public void before() {
+        TestEventTracker.startTracking();
+    }
+
+    @AfterEach
+    public void after() {
+        TestEventTracker.stopTracking();
+    }
+
+    @Test
+    public void testSuite() {
+        // to avoid confusion of duplicated test execution output
+        System.out.println(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>");
+        System.out.println(">>>EngineTestKit duplicating the suite>>>");
+        SmartDirtiesTestsHolder.reset(ENGINE);
+
+        var events = EngineTestKit.execute(ENGINE, request()
+                .selectors(selectPackage("com.github.seregamorph.testsmartcontext.demo"))
+                .filters(excludeClassNamePatterns(getClass().getName()))
+                .build())
+            .containerEvents();
+
+        // 7 = 5 ITs + 1 UTs + 1 suite
+        events.assertStatistics(stats -> stats
+            .started(7)
+            .succeeded(7)
+            .finished(7)
+            .aborted(0)
+            .failed(0));
+
+        assertEquals(5, SmartDirtiesTestsHolder.classOrderStateMapSize(ENGINE));
+
+        assertTrue(SmartDirtiesTestsHolder.isFirstClassPerConfig(ExtendWithTest.class));
+        assertFalse(SmartDirtiesTestsHolder.isFirstClassPerConfig(Integration2SpringJUnitConfigTest.NestedTest.class));
+        assertTrue(SmartDirtiesTestsHolder.isFirstClassPerConfig(Integration2SpringJUnitConfigTest.class));
+        assertFalse(SmartDirtiesTestsHolder.isFirstClassPerConfig(NoBaseClass1IntegrationTest.class));
+        assertFalse(SmartDirtiesTestsHolder.isFirstClassPerConfig(NoBaseClass2IntegrationTest.class));
+        assertTrue(SmartDirtiesTestsHolder.isFirstClassPerConfig(SampleIntegrationTest.class));
+
+        assertFalse(SmartDirtiesTestsHolder.isLastClassPerConfig(ExtendWithTest.class));
+        assertFalse(SmartDirtiesTestsHolder.isLastClassPerConfig(Integration2SpringJUnitConfigTest.NestedTest.class));
+        assertTrue(SmartDirtiesTestsHolder.isLastClassPerConfig(Integration2SpringJUnitConfigTest.class));
+        assertFalse(SmartDirtiesTestsHolder.isLastClassPerConfig(NoBaseClass1IntegrationTest.class));
+        assertTrue(SmartDirtiesTestsHolder.isLastClassPerConfig(NoBaseClass2IntegrationTest.class));
+        assertTrue(SmartDirtiesTestsHolder.isLastClassPerConfig(SampleIntegrationTest.class));
+
+        TestEventTracker.assertConsumedEvent("Creating context for com.github.seregamorph.testsmartcontext.demo.ExtendWithTest");
+        TestEventTracker.assertConsumedEvent("Created context for com.github.seregamorph.testsmartcontext.demo.ExtendWithTest");
+        TestEventTracker.assertConsumedEvent("Destroying context for com.github.seregamorph.testsmartcontext.demo.NoBaseClass2IntegrationTest");
+        TestEventTracker.assertConsumedEvent("Creating context for com.github.seregamorph.testsmartcontext.demo.Integration2SpringJUnitConfigTest");
+        TestEventTracker.assertConsumedEvent("Created context for com.github.seregamorph.testsmartcontext.demo.Integration2SpringJUnitConfigTest");
+        TestEventTracker.assertConsumedEvent("Destroying context for com.github.seregamorph.testsmartcontext.demo.Integration2SpringJUnitConfigTest");
+        TestEventTracker.assertConsumedEvent("Creating context for com.github.seregamorph.testsmartcontext.demo.SampleIntegrationTest");
+        TestEventTracker.assertConsumedEvent("Created context for com.github.seregamorph.testsmartcontext.demo.SampleIntegrationTest");
+        TestEventTracker.assertConsumedEvent("Destroying context for com.github.seregamorph.testsmartcontext.demo.SampleIntegrationTest");
+        TestEventTracker.assertEmpty();
+
+        System.out.println("<<<EngineTestKit duplicating the suite<<<");
+        System.out.println("<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<");
+    }
+}

--- a/demo/demo-maven-junit-platform-mixed-boot34/src/test/java/com/github/seregamorph/testsmartcontext/MavenSmartDirtiesTestngEngineTest.java
+++ b/demo/demo-maven-junit-platform-mixed-boot34/src/test/java/com/github/seregamorph/testsmartcontext/MavenSmartDirtiesTestngEngineTest.java
@@ -1,0 +1,69 @@
+package com.github.seregamorph.testsmartcontext;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectPackage;
+import static org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.request;
+
+import com.github.seregamorph.testsmartcontext.demo.Integration1Test;
+import com.github.seregamorph.testsmartcontext.demo.SampleDirtiesContextAfterClassTest;
+import com.github.seregamorph.testsmartcontext.testkit.TestEventTracker;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.testkit.engine.EngineTestKit;
+
+public class MavenSmartDirtiesTestngEngineTest {
+
+    private static final String ENGINE = "testng";
+
+    @BeforeEach
+    public void before() {
+        TestEventTracker.startTracking();
+    }
+
+    @AfterEach
+    public void after() {
+        TestEventTracker.stopTracking();
+    }
+
+    @Test
+    public void testSuite() {
+        // to avoid confusion of duplicated test execution output
+        System.out.println(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>");
+        System.out.println(">>>EngineTestKit duplicating the suite>>>");
+        SmartDirtiesTestsHolder.reset(ENGINE);
+
+        var events = EngineTestKit.execute(ENGINE, request()
+                .selectors(selectPackage("com.github.seregamorph.testsmartcontext.demo"))
+                .build())
+            .containerEvents();
+
+        // 3 = 2 ITs + 0 UTs + 1 suite
+        events.assertStatistics(stats -> stats
+            .started(3)
+            .succeeded(3)
+            .finished(3)
+            .aborted(0)
+            .failed(0));
+
+        assertEquals(2, SmartDirtiesTestsHolder.classOrderStateMapSize(ENGINE));
+
+        assertTrue(SmartDirtiesTestsHolder.isFirstClassPerConfig(Integration1Test.class));
+        assertTrue(SmartDirtiesTestsHolder.isFirstClassPerConfig(SampleDirtiesContextAfterClassTest.class));
+
+        assertTrue(SmartDirtiesTestsHolder.isLastClassPerConfig(Integration1Test.class));
+        assertTrue(SmartDirtiesTestsHolder.isLastClassPerConfig(SampleDirtiesContextAfterClassTest.class));
+
+        TestEventTracker.assertConsumedEvent("Creating context for com.github.seregamorph.testsmartcontext.demo.Integration1Test");
+        TestEventTracker.assertConsumedEvent("Created context for com.github.seregamorph.testsmartcontext.demo.Integration1Test");
+        TestEventTracker.assertConsumedEvent("Destroying context for com.github.seregamorph.testsmartcontext.demo.Integration1Test");
+        TestEventTracker.assertConsumedEvent("Creating context for com.github.seregamorph.testsmartcontext.demo.SampleDirtiesContextAfterClassTest");
+        TestEventTracker.assertConsumedEvent("Created context for com.github.seregamorph.testsmartcontext.demo.SampleDirtiesContextAfterClassTest");
+        TestEventTracker.assertConsumedEvent("Destroying context for com.github.seregamorph.testsmartcontext.demo.SampleDirtiesContextAfterClassTest");
+        TestEventTracker.assertEmpty();
+
+        System.out.println("<<<EngineTestKit duplicating the suite<<<");
+        System.out.println("<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<");
+    }
+}

--- a/demo/demo-maven-junit-platform-mixed-boot34/src/test/java/com/github/seregamorph/testsmartcontext/MavenSmartDirtiesVintageEngineTest.java
+++ b/demo/demo-maven-junit-platform-mixed-boot34/src/test/java/com/github/seregamorph/testsmartcontext/MavenSmartDirtiesVintageEngineTest.java
@@ -1,0 +1,72 @@
+package com.github.seregamorph.testsmartcontext;
+
+import com.github.seregamorph.testsmartcontext.demo.Integration2Test;
+import com.github.seregamorph.testsmartcontext.demo.SampleDirtiesContextBeforeClassTest;
+import com.github.seregamorph.testsmartcontext.testkit.TestEventTracker;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.testkit.engine.EngineTestKit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectPackage;
+import static org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.request;
+
+public class MavenSmartDirtiesVintageEngineTest {
+
+    private static final String ENGINE = "junit-vintage";
+
+    @BeforeEach
+    public void before() {
+        TestEventTracker.startTracking();
+    }
+
+    @AfterEach
+    public void after() {
+        TestEventTracker.stopTracking();
+    }
+
+    @Test
+    public void testSuite() {
+        // to avoid confusion of duplicated test execution output
+        System.out.println(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>");
+        System.out.println(">>>EngineTestKit duplicating the suite>>>");
+        SmartDirtiesTestsHolder.reset(ENGINE);
+
+        var events = EngineTestKit.execute(ENGINE, request()
+                .selectors(selectPackage("com.github.seregamorph.testsmartcontext.demo"))
+                .filters(new SmartDirtiesPostDiscoveryFilter())
+                .build())
+            .containerEvents();
+
+        // 4 = 2 ITs + 1 UTs + 1 suite
+        events.assertStatistics(stats -> stats
+            .started(4)
+            .succeeded(4)
+            .finished(4)
+            .aborted(0)
+            .failed(0));
+
+        assertEquals(2, SmartDirtiesTestsHolder.classOrderStateMapSize(ENGINE));
+
+        assertTrue(SmartDirtiesTestsHolder.isFirstClassPerConfig(Integration2Test.class));
+        assertTrue(SmartDirtiesTestsHolder.isFirstClassPerConfig(SampleDirtiesContextBeforeClassTest.class));
+
+        assertTrue(SmartDirtiesTestsHolder.isLastClassPerConfig(Integration2Test.class));
+        assertTrue(SmartDirtiesTestsHolder.isLastClassPerConfig(SampleDirtiesContextBeforeClassTest.class));
+
+        TestEventTracker.assertConsumedEvent("Running com.github.seregamorph.testsmartcontext.demo.Unit1Test.test");
+        TestEventTracker.assertConsumedEvent("Creating context for com.github.seregamorph.testsmartcontext.demo.Integration2Test");
+        TestEventTracker.assertConsumedEvent("Created context for com.github.seregamorph.testsmartcontext.demo.Integration2Test");
+        TestEventTracker.assertConsumedEvent("Destroying context for com.github.seregamorph.testsmartcontext.demo.Integration2Test");
+        TestEventTracker.assertConsumedEvent("Creating context for com.github.seregamorph.testsmartcontext.demo.SampleDirtiesContextBeforeClassTest");
+        TestEventTracker.assertConsumedEvent("Created context for com.github.seregamorph.testsmartcontext.demo.SampleDirtiesContextBeforeClassTest");
+        TestEventTracker.assertConsumedEvent("Running SampleDirtiesContextBeforeClassTest.test");
+        TestEventTracker.assertConsumedEvent("Destroying context for com.github.seregamorph.testsmartcontext.demo.SampleDirtiesContextBeforeClassTest");
+        TestEventTracker.assertEmpty();
+
+        System.out.println("<<<EngineTestKit duplicating the suite<<<");
+        System.out.println("<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<");
+    }
+}

--- a/demo/demo-maven-junit-platform-mixed-boot34/src/test/java/com/github/seregamorph/testsmartcontext/demo/ExtendWithTest.java
+++ b/demo/demo-maven-junit-platform-mixed-boot34/src/test/java/com/github/seregamorph/testsmartcontext/demo/ExtendWithTest.java
@@ -1,0 +1,17 @@
+package com.github.seregamorph.testsmartcontext.demo;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+
+// JUnit 5 Jupiter
+@SpringBootTest(classes = SampleIntegrationTest.Configuration.class)
+@ExtendWith(OutputCaptureExtension.class)
+public class ExtendWithTest {
+
+    @Test
+    public void test() {
+        System.out.println("Running " + getClass().getName() + ".test");
+    }
+}

--- a/demo/demo-maven-junit-platform-mixed-boot34/src/test/java/com/github/seregamorph/testsmartcontext/demo/Integration1Test.java
+++ b/demo/demo-maven-junit-platform-mixed-boot34/src/test/java/com/github/seregamorph/testsmartcontext/demo/Integration1Test.java
@@ -1,0 +1,29 @@
+package com.github.seregamorph.testsmartcontext.demo;
+
+import com.github.seregamorph.testsmartcontext.testng.AbstractTestNGSpringIntegrationTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.testng.annotations.Test;
+
+// TestNG
+@WebAppConfiguration
+@ContextConfiguration(classes = {
+    Integration1Test.Configuration.class
+})
+public class Integration1Test extends AbstractTestNGSpringIntegrationTest {
+
+    @Autowired
+    private SampleBean rootBean;
+
+    @Test
+    public void test() {
+        System.out.println("Integration1Test.test " + rootBean);
+    }
+
+    @Import(SampleBean.class)
+    public static class Configuration {
+
+    }
+}

--- a/demo/demo-maven-junit-platform-mixed-boot34/src/test/java/com/github/seregamorph/testsmartcontext/demo/Integration2SpringJUnitConfigTest.java
+++ b/demo/demo-maven-junit-platform-mixed-boot34/src/test/java/com/github/seregamorph/testsmartcontext/demo/Integration2SpringJUnitConfigTest.java
@@ -1,0 +1,27 @@
+package com.github.seregamorph.testsmartcontext.demo;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+// JUnit 5 Jupiter
+@SpringJUnitConfig(classes = {
+    Integration2Test.Configuration.class
+})
+public class Integration2SpringJUnitConfigTest {
+
+    @Test
+    public void test() {
+        System.out.println("Integration2SpringJUnitConfigTest.test");
+    }
+
+    @Nested
+    public class NestedTest {
+
+        @Test
+        public void nested() {
+            System.out.println("Integration2Test.NestedTest.test");
+        }
+    }
+
+}

--- a/demo/demo-maven-junit-platform-mixed-boot34/src/test/java/com/github/seregamorph/testsmartcontext/demo/Integration2Test.java
+++ b/demo/demo-maven-junit-platform-mixed-boot34/src/test/java/com/github/seregamorph/testsmartcontext/demo/Integration2Test.java
@@ -1,0 +1,21 @@
+package com.github.seregamorph.testsmartcontext.demo;
+
+import com.github.seregamorph.testsmartcontext.junit4.AbstractJUnit4SpringIntegrationTest;
+import org.junit.Test;
+import org.springframework.test.context.ContextConfiguration;
+
+// JUnit 4
+@ContextConfiguration(classes = {
+    Integration2Test.Configuration.class
+})
+public class Integration2Test extends AbstractJUnit4SpringIntegrationTest {
+
+    @Test
+    public void test() {
+        System.out.println("Integration2Test.test");
+    }
+
+    public static class Configuration {
+
+    }
+}

--- a/demo/demo-maven-junit-platform-mixed-boot34/src/test/java/com/github/seregamorph/testsmartcontext/demo/NoBaseClass1IntegrationTest.java
+++ b/demo/demo-maven-junit-platform-mixed-boot34/src/test/java/com/github/seregamorph/testsmartcontext/demo/NoBaseClass1IntegrationTest.java
@@ -1,0 +1,14 @@
+package com.github.seregamorph.testsmartcontext.demo;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+// JUnit 5 Jupiter
+@SpringBootTest(classes = SampleIntegrationTest.Configuration.class)
+public class NoBaseClass1IntegrationTest {
+
+    @Test
+    public void test() {
+        System.out.println("Running " + getClass().getName() + ".test");
+    }
+}

--- a/demo/demo-maven-junit-platform-mixed-boot34/src/test/java/com/github/seregamorph/testsmartcontext/demo/NoBaseClass2IntegrationTest.java
+++ b/demo/demo-maven-junit-platform-mixed-boot34/src/test/java/com/github/seregamorph/testsmartcontext/demo/NoBaseClass2IntegrationTest.java
@@ -1,0 +1,14 @@
+package com.github.seregamorph.testsmartcontext.demo;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+// JUnit 5 Jupiter
+@SpringBootTest(classes = SampleIntegrationTest.Configuration.class)
+public class NoBaseClass2IntegrationTest {
+
+    @Test
+    public void test() {
+        System.out.println("Running " + getClass().getName() + ".test");
+    }
+}

--- a/demo/demo-maven-junit-platform-mixed-boot34/src/test/java/com/github/seregamorph/testsmartcontext/demo/SampleBean.java
+++ b/demo/demo-maven-junit-platform-mixed-boot34/src/test/java/com/github/seregamorph/testsmartcontext/demo/SampleBean.java
@@ -1,0 +1,4 @@
+package com.github.seregamorph.testsmartcontext.demo;
+
+public class SampleBean {
+}

--- a/demo/demo-maven-junit-platform-mixed-boot34/src/test/java/com/github/seregamorph/testsmartcontext/demo/SampleDirtiesContextAfterClassTest.java
+++ b/demo/demo-maven-junit-platform-mixed-boot34/src/test/java/com/github/seregamorph/testsmartcontext/demo/SampleDirtiesContextAfterClassTest.java
@@ -1,0 +1,17 @@
+package com.github.seregamorph.testsmartcontext.demo;
+
+import com.github.seregamorph.testsmartcontext.testng.AbstractTestNGSpringIntegrationTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.testng.annotations.Test;
+
+// TestNG
+@ContextConfiguration(classes = Integration1Test.Configuration.class)
+@DirtiesContext
+public class SampleDirtiesContextAfterClassTest extends AbstractTestNGSpringIntegrationTest {
+
+    @Test
+    public void test() {
+        System.out.println("Running " + getClass().getName() + ".test");
+    }
+}

--- a/demo/demo-maven-junit-platform-mixed-boot34/src/test/java/com/github/seregamorph/testsmartcontext/demo/SampleDirtiesContextBeforeClassTest.java
+++ b/demo/demo-maven-junit-platform-mixed-boot34/src/test/java/com/github/seregamorph/testsmartcontext/demo/SampleDirtiesContextBeforeClassTest.java
@@ -1,0 +1,18 @@
+package com.github.seregamorph.testsmartcontext.demo;
+
+import com.github.seregamorph.testsmartcontext.junit4.AbstractJUnit4SpringIntegrationTest;
+import com.github.seregamorph.testsmartcontext.testkit.TestEventTracker;
+import org.junit.Test;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+
+// JUnit 4
+@ContextConfiguration(classes = Integration1Test.Configuration.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_CLASS)
+public class SampleDirtiesContextBeforeClassTest extends AbstractJUnit4SpringIntegrationTest {
+
+    @Test
+    public void test() {
+        TestEventTracker.trackEvent("Running " + getClass().getSimpleName() + ".test");
+    }
+}

--- a/demo/demo-maven-junit-platform-mixed-boot34/src/test/java/com/github/seregamorph/testsmartcontext/demo/SampleIntegrationTest.java
+++ b/demo/demo-maven-junit-platform-mixed-boot34/src/test/java/com/github/seregamorph/testsmartcontext/demo/SampleIntegrationTest.java
@@ -1,0 +1,47 @@
+package com.github.seregamorph.testsmartcontext.demo;
+
+import com.github.seregamorph.testsmartcontext.jupiter.AbstractJUnitSpringIntegrationTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.DefaultMockMvcBuilder;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+// JUnit 5 Jupiter
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@ContextConfiguration(classes = {
+    SampleIntegrationTest.Configuration.class
+})
+@ActiveProfiles("test")
+@TestPropertySource(properties = {
+    "parameter = value"
+})
+public class SampleIntegrationTest extends AbstractJUnitSpringIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    public void test404() throws Exception {
+        mockMvc.perform(get("/article"))
+            .andExpect(status().isNotFound());
+    }
+
+    public static class Configuration {
+
+        @Bean
+        public MockMvc mockMvc(WebApplicationContext webApplicationContext) {
+            DefaultMockMvcBuilder builder = MockMvcBuilders.webAppContextSetup(webApplicationContext);
+            return builder.build();
+        }
+    }
+}

--- a/demo/demo-maven-junit-platform-mixed-boot34/src/test/java/com/github/seregamorph/testsmartcontext/demo/Unit1Test.java
+++ b/demo/demo-maven-junit-platform-mixed-boot34/src/test/java/com/github/seregamorph/testsmartcontext/demo/Unit1Test.java
@@ -1,0 +1,16 @@
+package com.github.seregamorph.testsmartcontext.demo;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.github.seregamorph.testsmartcontext.testkit.TestEventTracker;
+import org.junit.Test;
+
+// JUnit 4
+public class Unit1Test {
+
+    @Test
+    public void test() {
+        TestEventTracker.trackEvent("Running " + getClass().getName() + ".test");
+        assertTrue(true);
+    }
+}

--- a/demo/demo-maven-junit-platform-mixed-boot34/src/test/resources/logback-test.xml
+++ b/demo/demo-maven-junit-platform-mixed-boot34/src/test/resources/logback-test.xml
@@ -1,0 +1,11 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss} [%thread] %-5level %logger - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/demo/demo-maven-junit-platform-testng-boot32/src/test/java/com/github/seregamorph/testsmartcontext/SmartDirtiesTestngEngineTest.java
+++ b/demo/demo-maven-junit-platform-testng-boot32/src/test/java/com/github/seregamorph/testsmartcontext/SmartDirtiesTestngEngineTest.java
@@ -18,6 +18,8 @@ import org.testng.annotations.Test;
 
 public class SmartDirtiesTestngEngineTest {
 
+    private static final String ENGINE = "testng";
+
     @BeforeMethod
     public void before() {
         TestEventTracker.startTracking();
@@ -33,9 +35,9 @@ public class SmartDirtiesTestngEngineTest {
         // to avoid confusion of duplicated test execution output
         System.out.println(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>");
         System.out.println(">>>EngineTestKit duplicating the suite>>>");
-        SmartDirtiesTestsHolder.reset();
+        SmartDirtiesTestsHolder.reset(ENGINE);
 
-        var events = EngineTestKit.execute("testng", request()
+        var events = EngineTestKit.execute(ENGINE, request()
                 .selectors(selectPackage("com.github.seregamorph.testsmartcontext.demo"))
                 .build())
             .containerEvents();
@@ -48,7 +50,7 @@ public class SmartDirtiesTestngEngineTest {
             .aborted(0)
             .failed(0));
 
-        assertEquals(4, SmartDirtiesTestsHolder.classOrderStateMapSize());
+        assertEquals(4, SmartDirtiesTestsHolder.classOrderStateMapSize(ENGINE));
 
         assertTrue(SmartDirtiesTestsHolder.isFirstClassPerConfig(Integration1SecondIT.class));
         assertFalse(SmartDirtiesTestsHolder.isFirstClassPerConfig(Integration1IT.class));

--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -27,6 +27,7 @@
         <module>demo-maven-junit-platform-junit4-boot24</module>
         <module>demo-maven-junit-platform-jupiter-boot34</module>
         <module>demo-maven-junit-platform-jupiter-spring5</module>
+        <module>demo-maven-junit-platform-mixed-boot34</module>
         <module>demo-maven-junit-platform-testng-boot32</module>
         <module>demo-maven-testng-boot24</module>
         <module>demo-testkit</module>

--- a/spring-test-smart-context/src/main/java/com/github/seregamorph/testsmartcontext/SmartDirtiesPostDiscoveryFilter.java
+++ b/spring-test-smart-context/src/main/java/com/github/seregamorph/testsmartcontext/SmartDirtiesPostDiscoveryFilter.java
@@ -27,6 +27,8 @@ import org.springframework.lang.Nullable;
 @Deprecated
 public class SmartDirtiesPostDiscoveryFilter implements PostDiscoveryFilter {
 
+    private static final String ENGINE = "junit-vintage";
+
     @Override
     public FilterResult apply(TestDescriptor testDescriptor) {
         List<TestDescriptor> childrenToReorder = testDescriptor.getChildren().stream()
@@ -51,9 +53,9 @@ public class SmartDirtiesPostDiscoveryFilter implements PostDiscoveryFilter {
             // it's not possible to distinguish them here. Sometimes per single test is sent as argument,
             // sometimes - the whole suite. If it's a suite more than 1, we can save it and never update.
             // If it's 1 - we should also distinguish single test execution.
-            if (SmartDirtiesTestsHolder.classOrderStateMapSize() <= 1) {
+            if (SmartDirtiesTestsHolder.classOrderStateMapSize(ENGINE) <= 1) {
                 Class<?> testClass = getTestClass(childrenToReorder.get(0));
-                SmartDirtiesTestsHolder.setTestClassesLists(singletonList(singletonList(testClass)));
+                SmartDirtiesTestsHolder.setTestClassesLists(ENGINE, singletonList(singletonList(testClass)));
             }
 
             // the logic here may differ for JUnit 4 via Maven vs IntelliJ:
@@ -68,7 +70,7 @@ public class SmartDirtiesPostDiscoveryFilter implements PostDiscoveryFilter {
 
         childrenToReorder.forEach(testDescriptor::addChild);
 
-        SmartDirtiesTestsHolder.setTestClassesLists(testClassesLists);
+        SmartDirtiesTestsHolder.setTestClassesLists(ENGINE, testClassesLists);
 
         return FilterResult.included("sorted");
     }

--- a/spring-test-smart-context/src/main/java/com/github/seregamorph/testsmartcontext/jupiter/SmartDirtiesClassOrderer.java
+++ b/spring-test-smart-context/src/main/java/com/github/seregamorph/testsmartcontext/jupiter/SmartDirtiesClassOrderer.java
@@ -25,6 +25,8 @@ import org.springframework.core.annotation.AnnotationUtils;
  */
 public class SmartDirtiesClassOrderer extends SmartDirtiesTestsHolder implements ClassOrderer {
 
+    private static final String ENGINE = "junit-jupiter";
+
     @Override
     public void orderClasses(ClassOrdererContext context) {
         List<? extends ClassDescriptor> classDescriptors = context.getClassDescriptors();
@@ -66,7 +68,7 @@ public class SmartDirtiesClassOrderer extends SmartDirtiesTestsHolder implements
         if (uniqueClasses.isEmpty()) {
             // All are internal (@Nested), we do not reorder them.
             // The enclosing classes are already in the SmartDirtiesTestsHolder from previous call
-            if (SmartDirtiesTestsHolder.classOrderStateMapSize() == 0) {
+            if (SmartDirtiesTestsHolder.classOrderStateMapSize(ENGINE) == 0) {
                 throw new IllegalStateException("orderClasses is called with inner classes list " + classDescriptors
                     + " before being called with enclosing class list");
             }
@@ -78,9 +80,9 @@ public class SmartDirtiesClassOrderer extends SmartDirtiesTestsHolder implements
             // it's not possible to distinguish them here. Sometimes per single test is sent as argument,
             // sometimes - the whole suite. If it's a suite more than 1, we can save it and never update.
             // If it's 1 - we should also distinguish single test execution.
-            if (SmartDirtiesTestsHolder.classOrderStateMapSize() <= 1) {
+            if (SmartDirtiesTestsHolder.classOrderStateMapSize(ENGINE) <= 1) {
                 Class<?> testClass = classDescriptors.get(0).getTestClass();
-                SmartDirtiesTestsHolder.setTestClassesLists(singletonList(singletonList(testClass)));
+                SmartDirtiesTestsHolder.setTestClassesLists(ENGINE, singletonList(singletonList(testClass)));
             }
             return;
         }
@@ -88,6 +90,6 @@ public class SmartDirtiesClassOrderer extends SmartDirtiesTestsHolder implements
         SmartDirtiesTestsSorter sorter = SmartDirtiesTestsSorter.getInstance();
         List<List<Class<?>>> testClassesLists = sorter.sort(classDescriptors, ClassDescriptor::getTestClass);
 
-        SmartDirtiesTestsHolder.setTestClassesLists(testClassesLists);
+        SmartDirtiesTestsHolder.setTestClassesLists(ENGINE, testClassesLists);
     }
 }

--- a/spring-test-smart-context/src/main/java/com/github/seregamorph/testsmartcontext/testng/SmartDirtiesSuiteListener.java
+++ b/spring-test-smart-context/src/main/java/com/github/seregamorph/testsmartcontext/testng/SmartDirtiesSuiteListener.java
@@ -26,6 +26,8 @@ import org.testng.xml.XmlSuite;
 public class SmartDirtiesSuiteListener extends SmartDirtiesTestsHolder
     implements IAlterSuiteListener, IMethodInterceptor {
 
+    private static final String ENGINE = "testng";
+
     @Override
     public void alter(List<XmlSuite> suites) {
         // dryRun is only true when called via junit5 testng-engine on discovery phase, there will be subsequent
@@ -57,7 +59,7 @@ public class SmartDirtiesSuiteListener extends SmartDirtiesTestsHolder
             return methodInstance.getMethod().getTestClass().getRealClass();
         });
 
-        SmartDirtiesTestsHolder.setTestClassesLists(testClassesLists);
+        SmartDirtiesTestsHolder.setTestClassesLists(ENGINE, testClassesLists);
 
         return methods;
     }


### PR DESCRIPTION
JUnit 5 platform supports several test engines simultaneosly:
* JUnit 4 (`junit-vintage`)
* JUnit 5 Jupiter (`junit-jupiter`)
* TestNG (`testng`)

and tests of these engines can be mixed in a single classpath.
With this change it's now properly supported.