### PR TITLE
Additional failure cause diagnostics

### DIFF
--- a/spring-test-smart-context/src/main/java/com/github/seregamorph/testsmartcontext/SmartDirtiesPostDiscoveryFilter.java
+++ b/spring-test-smart-context/src/main/java/com/github/seregamorph/testsmartcontext/SmartDirtiesPostDiscoveryFilter.java
@@ -66,8 +66,13 @@ public class SmartDirtiesPostDiscoveryFilter implements PostDiscoveryFilter {
         childrenToReorder.forEach(testDescriptor::removeChild);
 
         SmartDirtiesTestsSorter sorter = SmartDirtiesTestsSorter.getInstance();
-        List<List<Class<?>>> testClassesLists = sorter.sort(childrenToReorder,
-            SmartDirtiesPostDiscoveryFilter::getTestClass);
+        List<List<Class<?>>> testClassesLists;
+        try {
+            testClassesLists = sorter.sort(childrenToReorder, SmartDirtiesPostDiscoveryFilter::getTestClass);
+        } catch (Throwable e) {
+            SmartDirtiesTestsSupport.setFailureCause(e);
+            throw e;
+        }
 
         childrenToReorder.forEach(testDescriptor::addChild);
 

--- a/spring-test-smart-context/src/main/java/com/github/seregamorph/testsmartcontext/SmartDirtiesTestsSupport.java
+++ b/spring-test-smart-context/src/main/java/com/github/seregamorph/testsmartcontext/SmartDirtiesTestsSupport.java
@@ -31,6 +31,9 @@ public class SmartDirtiesTestsSupport {
      */
     private static Map<String, Map<Class<?>, ClassOrderState>> engineClassOrderStateMap;
 
+    @Nullable
+    private static Throwable failureCause;
+
     static class ClassOrderState {
         private final boolean isFirst;
         private final boolean isLast;
@@ -97,7 +100,7 @@ public class SmartDirtiesTestsSupport {
                                     + ClassOrderer.DEFAULT_ORDER_PROPERTY_NAME + " property" : "declares\n"
                                     + ClassOrderer.DEFAULT_ORDER_PROPERTY_NAME + "=" + configClassOrderer + "\n")
                                 + " (should have value " + SmartDirtiesClassOrderer.class.getName()
-                                + " to address the issue)");
+                                + " to address the issue)", failureCause);
                             //@formatter:on
                         }
                         //@formatter:off
@@ -128,7 +131,7 @@ public class SmartDirtiesTestsSupport {
                 }
                 return null;
             }
-            throw new IllegalStateException("engineClassOrderStateMap is not initialized");
+            throw new IllegalStateException("engineClassOrderStateMap is not initialized", failureCause);
         }
 
         for (Map<Class<?>, ClassOrderState> classOrderStateMap : engineClassOrderStateMap.values()) {
@@ -138,10 +141,10 @@ public class SmartDirtiesTestsSupport {
             }
         }
         throw new IllegalStateException("engineClassOrderStateMap is not defined for class "
-            + testClass + ", it means that it was skipped on initial analysis. "
+            + testClass + ", it means that it was skipped on initial analysis or failed. "
             + "Discovered classes: " + engineClassOrderStateMap.entrySet().stream()
             .map(entry -> entry.getKey() + ": " + entry.getValue().keySet())
-            .collect(Collectors.toList()));
+            .collect(Collectors.toList()), failureCause);
     }
 
     protected static void setTestClassesLists(String engine, List<List<Class<?>>> testClassesLists) {
@@ -159,6 +162,10 @@ public class SmartDirtiesTestsSupport {
             SmartDirtiesTestsSupport.engineClassOrderStateMap = new LinkedHashMap<>();
         }
         SmartDirtiesTestsSupport.engineClassOrderStateMap.put(engine, classOrderStateMap);
+    }
+
+    protected static void setFailureCause(Throwable failureCause) {
+        SmartDirtiesTestsSupport.failureCause = failureCause;
     }
 
     protected static void verifyInnerClass(Class<?> innerTestClass) {

--- a/spring-test-smart-context/src/main/java/com/github/seregamorph/testsmartcontext/jupiter/SmartDirtiesClassOrderer.java
+++ b/spring-test-smart-context/src/main/java/com/github/seregamorph/testsmartcontext/jupiter/SmartDirtiesClassOrderer.java
@@ -88,8 +88,13 @@ public class SmartDirtiesClassOrderer extends SmartDirtiesTestsSupport implement
         }
 
         SmartDirtiesTestsSorter sorter = SmartDirtiesTestsSorter.getInstance();
-        List<List<Class<?>>> testClassesLists = sorter.sort(classDescriptors, ClassDescriptor::getTestClass);
-
+        List<List<Class<?>>> testClassesLists;
+        try {
+            testClassesLists = sorter.sort(classDescriptors, ClassDescriptor::getTestClass);
+        } catch (Throwable e) {
+            SmartDirtiesTestsSupport.setFailureCause(e);
+            throw e;
+        }
         SmartDirtiesTestsSupport.setTestClassesLists(ENGINE, testClassesLists);
     }
 }

--- a/spring-test-smart-context/src/main/java/com/github/seregamorph/testsmartcontext/testng/SmartDirtiesSuiteListener.java
+++ b/spring-test-smart-context/src/main/java/com/github/seregamorph/testsmartcontext/testng/SmartDirtiesSuiteListener.java
@@ -55,6 +55,8 @@ public class SmartDirtiesSuiteListener extends SmartDirtiesTestsSupport
 
         // this intercept method is executed by TestNG before running the suite (both IDEA and maven)
         SmartDirtiesTestsSorter sorter = SmartDirtiesTestsSorter.getInstance();
+        // Do not store the failure as if it throws, TestNG will fail the suite
+        // (both pure TestNG and JUnit 5 testng-engine)
         List<List<Class<?>>> testClassesLists = sorter.sort(methods, SmartDirtiesSuiteListener::getTestClass);
 
         SmartDirtiesTestsSupport.setTestClassesLists(ENGINE, testClassesLists);


### PR DESCRIPTION
Preserve possible failure cause of `SmartDirtiesTestsSorter.sort` to extend failure message diagnostics.