### PR TITLE
Switch to Slf4J logging

### DIFF
--- a/spring-test-smart-context/pom.xml
+++ b/spring-test-smart-context/pom.xml
@@ -18,6 +18,7 @@
     </description>
 
     <properties>
+        <slf4j.version>1.7.36</slf4j.version>
         <spring.version>6.1.16</spring.version>
         <testng.version>7.10.2</testng.version>
         <junit-platform.version>1.11.3</junit-platform.version>
@@ -51,10 +52,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-jcl</artifactId>
-            <version>${spring.version}</version>
-            <scope>provided</scope>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/spring-test-smart-context/src/main/java/com/github/seregamorph/testsmartcontext/SmartDirtiesContextTestExecutionListener.java
+++ b/spring-test-smart-context/src/main/java/com/github/seregamorph/testsmartcontext/SmartDirtiesContextTestExecutionListener.java
@@ -2,8 +2,8 @@ package com.github.seregamorph.testsmartcontext;
 
 import static com.github.seregamorph.testsmartcontext.SmartDirtiesTestsSupport.isInnerClass;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.test.context.TestContext;
 import org.springframework.test.context.support.AbstractTestExecutionListener;
 
@@ -24,7 +24,7 @@ import org.springframework.test.context.support.AbstractTestExecutionListener;
  */
 public class SmartDirtiesContextTestExecutionListener extends AbstractTestExecutionListener {
 
-    private static final Log LOG = LogFactory.getLog(SmartDirtiesContextTestExecutionListener.class);
+    private static final Logger logger = LoggerFactory.getLogger(SmartDirtiesContextTestExecutionListener.class);
 
     @Override
     public int getOrder() {
@@ -48,10 +48,10 @@ public class SmartDirtiesContextTestExecutionListener extends AbstractTestExecut
         try {
             Class<?> testClass = testContext.getTestClass();
             if (SmartDirtiesTestsSupport.isLastClassPerConfig(testClass)) {
-                LOG.info("markDirty (closing context) after " + testClass.getName());
+                logger.info("markDirty (closing context) after {}", testClass.getName());
                 testContext.markApplicationContextDirty(null);
             } else {
-                LOG.debug("Reusing context after " + testClass.getName());
+                logger.debug("Reusing context after {}", testClass.getName());
             }
         } finally {
             // pop Nested classes

--- a/spring-test-smart-context/src/main/java/com/github/seregamorph/testsmartcontext/SmartDirtiesTestsSorter.java
+++ b/spring-test-smart-context/src/main/java/com/github/seregamorph/testsmartcontext/SmartDirtiesTestsSorter.java
@@ -15,8 +15,8 @@ import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.BootstrapUtilsHelper;
@@ -35,7 +35,7 @@ import org.springframework.test.context.TestContextBootstrapper;
  */
 public class SmartDirtiesTestsSorter {
 
-    private final Log log = LogFactory.getLog(getClass());
+    private final Logger logger = LoggerFactory.getLogger(getClass());
 
     private static final SmartDirtiesTestsSorter instance = initInstance();
 
@@ -162,7 +162,7 @@ public class SmartDirtiesTestsSorter {
         pw.println("Running suite of " + totalTests + " tests. Integration test classes " +
             "(" + itClasses.size() + " classes):");
         itClasses.forEach(pw::println);
-        log.debug(sw.toString());
+        logger.debug(sw.toString());
     }
 
     private void printSuiteTestsPerConfig(int itClassesSize, List<List<Class<?>>> sortedConfigToTests) {
@@ -190,7 +190,7 @@ public class SmartDirtiesTestsSorter {
                 isFirst = false;
             }
         });
-        log.info(sw.toString());
+        logger.info(sw.toString());
     }
 
     @FunctionalInterface

--- a/spring-test-smart-context/src/main/java/com/github/seregamorph/testsmartcontext/SpringContextEventLoggerListener.java
+++ b/spring-test-smart-context/src/main/java/com/github/seregamorph/testsmartcontext/SpringContextEventLoggerListener.java
@@ -2,8 +2,8 @@ package com.github.seregamorph.testsmartcontext;
 
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.event.ApplicationContextEvent;
 import org.springframework.context.event.ContextClosedEvent;
@@ -17,7 +17,7 @@ import org.springframework.context.event.ContextRefreshedEvent;
  */
 public class SpringContextEventLoggerListener implements ApplicationListener<ApplicationContextEvent> {
 
-    private static final Log LOG = LogFactory.getLog(SpringContextEventLoggerListener.class);
+    private static final Logger logger = LoggerFactory.getLogger(SpringContextEventLoggerListener.class);
 
     private final long createdNanos = System.nanoTime();
 
@@ -28,11 +28,11 @@ public class SpringContextEventLoggerListener implements ApplicationListener<App
     protected void onCreated() {
         String currentTestClassName = CurrentTestContext.getCurrentTestClassName();
         if (currentTestClassName == null) {
-            LOG.error("Could not resolve current class name, ensure that SmartDirtiesContextTestExecutionListener " +
+            logger.error("Could not resolve current class name, ensure that SmartDirtiesContextTestExecutionListener " +
                 "is registered for test class. Hint:\n" +
                 "Maybe you should set @TestExecutionListeners.mergeMode to MERGE_WITH_DEFAULTS for your test class.");
         } else {
-            LOG.info("Creating context for " + currentTestClassName);
+            logger.info("Creating context for {}", currentTestClassName);
         }
     }
 
@@ -48,17 +48,17 @@ public class SpringContextEventLoggerListener implements ApplicationListener<App
     protected void onContextRefreshedEvent(ContextRefreshedEvent event) {
         long nowNanos = System.nanoTime();
         String contextInitFormatted = formatNanos(nowNanos - createdNanos);
-        LOG.info("Created context in " + contextInitFormatted + " for " + CurrentTestContext.getCurrentTestClassName());
+        logger.info("Created context in {} for {}", contextInitFormatted, CurrentTestContext.getCurrentTestClassName());
     }
 
     protected void onContextClosedEvent(ContextClosedEvent event) {
         String testClassIdentifier = CurrentTestContext.getCurrentTestClassName();
         if (testClassIdentifier == null) {
             // system shutdown hook
-            LOG.info("Destroying context (hook)");
+            logger.info("Destroying context (hook)");
         } else {
             // triggered via SmartDirtiesContextTestExecutionListener or spring DirtiesContextTestExecutionListener
-            LOG.info("Destroying context for " + testClassIdentifier);
+            logger.info("Destroying context for {}", testClassIdentifier);
         }
     }
 


### PR DESCRIPTION
There is a combination of logging library classes when `commons-logging` is not properly redirected to logger implementation. Also slf4j is used by other test libraries like testcontainers, so most probably engineers who adjusted testcontainers logs, would also adjust logs for this lib.