### PR TITLE
Distinguish child context events

### DIFF
--- a/demo/demo-maven-junit-platform-jupiter-boot35/pom.xml
+++ b/demo/demo-maven-junit-platform-jupiter-boot35/pom.xml
@@ -15,7 +15,7 @@
     <description>Demo project with tests launched via Maven junit-platform jupiter with spring-boot 3.5</description>
 
     <properties>
-        <spring-boot.version>3.5.0-M2</spring-boot.version>
+        <spring-boot.version>3.5.0-M3</spring-boot.version>
         <maven.install.skip>true</maven.install.skip>
     </properties>
 
@@ -51,6 +51,10 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
 
         <dependency>

--- a/demo/demo-maven-junit-platform-jupiter-boot35/src/test/java/com/github/seregamorph/testsmartcontext/MavenSmartDirtiesJupiterEngineTest.java
+++ b/demo/demo-maven-junit-platform-jupiter-boot35/src/test/java/com/github/seregamorph/testsmartcontext/MavenSmartDirtiesJupiterEngineTest.java
@@ -16,6 +16,7 @@ import com.github.seregamorph.testsmartcontext.demo.NoBaseClass2IntegrationTest;
 import com.github.seregamorph.testsmartcontext.demo.SampleDirtiesContextAfterClassTest;
 import com.github.seregamorph.testsmartcontext.demo.SampleDirtiesContextBeforeClassTest;
 import com.github.seregamorph.testsmartcontext.demo.SampleIntegrationTest;
+import com.github.seregamorph.testsmartcontext.demo.WebIntegrationTest;
 import com.github.seregamorph.testsmartcontext.testkit.TestEventTracker;
 import java.util.ArrayList;
 import java.util.List;
@@ -56,9 +57,9 @@ public class MavenSmartDirtiesJupiterEngineTest {
 
         // 16 = 10 ITs + 3 Nested + 2 UTs + 1 suite
         events.assertStatistics(stats -> stats
-            .started(16)
-            .succeeded(16)
-            .finished(16)
+            .started(17)
+            .succeeded(17)
+            .finished(17)
             .aborted(0)
             .failed(0));
 
@@ -72,7 +73,8 @@ public class MavenSmartDirtiesJupiterEngineTest {
             Integration1Test.class,
             Integration2SpringJUnitConfigTest.class,
             Integration2Test.class,
-            SampleIntegrationTest.class
+            SampleIntegrationTest.class,
+            WebIntegrationTest.class
         ), new ArrayList<>(TestSmartDirtiesTestsHolder.getIntegrationTestClasses(ENGINE)));
 
         assertTrue(SmartDirtiesTestsSupport.isFirstClassPerConfig(SampleDirtiesContextBeforeClassTest.class));
@@ -88,6 +90,7 @@ public class MavenSmartDirtiesJupiterEngineTest {
         assertFalse(SmartDirtiesTestsSupport.isFirstClassPerConfig(Integration2Test.class));
         assertFalse(SmartDirtiesTestsSupport.isFirstClassPerConfig(Integration2Test.NestedTest.class));
         assertTrue(SmartDirtiesTestsSupport.isFirstClassPerConfig(SampleIntegrationTest.class));
+        assertTrue(SmartDirtiesTestsSupport.isFirstClassPerConfig(WebIntegrationTest.class));
 
         assertFalse(SmartDirtiesTestsSupport.isLastClassPerConfig(SampleDirtiesContextBeforeClassTest.class));
         assertFalse(SmartDirtiesTestsSupport.isLastClassPerConfig(ExtendWithTest.class));
@@ -102,6 +105,7 @@ public class MavenSmartDirtiesJupiterEngineTest {
         assertFalse(SmartDirtiesTestsSupport.isFirstClassPerConfig(Integration2Test.NestedTest.class));
         assertTrue(SmartDirtiesTestsSupport.isLastClassPerConfig(Integration2Test.class));
         assertTrue(SmartDirtiesTestsSupport.isLastClassPerConfig(SampleIntegrationTest.class));
+        assertTrue(SmartDirtiesTestsSupport.isLastClassPerConfig(WebIntegrationTest.class));
 
         TestEventTracker.assertConsumedEvent("Started SmartDirtiesJupiterTestsSorterTest.shouldSortMostlyAlphabeticallyAndGroupSameConfigurations");
         TestEventTracker.assertConsumedEvent("Finished SmartDirtiesJupiterTestsSorterTest.shouldSortMostlyAlphabeticallyAndGroupSameConfigurations");
@@ -122,6 +126,9 @@ public class MavenSmartDirtiesJupiterEngineTest {
         TestEventTracker.assertConsumedEvent("Creating context for com.github.seregamorph.testsmartcontext.demo.SampleIntegrationTest");
         TestEventTracker.assertConsumedEvent("Created context for com.github.seregamorph.testsmartcontext.demo.SampleIntegrationTest");
         TestEventTracker.assertConsumedEvent("Destroying context for com.github.seregamorph.testsmartcontext.demo.SampleIntegrationTest");
+        TestEventTracker.assertConsumedEvent("Creating context for com.github.seregamorph.testsmartcontext.demo.WebIntegrationTest");
+        TestEventTracker.assertConsumedEvent("Created context for com.github.seregamorph.testsmartcontext.demo.WebIntegrationTest");
+        TestEventTracker.assertConsumedEvent("Destroying context for com.github.seregamorph.testsmartcontext.demo.WebIntegrationTest");
         TestEventTracker.assertEmpty();
 
         System.out.println("<<<EngineTestKit duplicating the suite<<<");

--- a/demo/demo-maven-junit-platform-jupiter-boot35/src/test/java/com/github/seregamorph/testsmartcontext/demo/WebIntegrationTest.java
+++ b/demo/demo-maven-junit-platform-jupiter-boot35/src/test/java/com/github/seregamorph/testsmartcontext/demo/WebIntegrationTest.java
@@ -1,0 +1,37 @@
+package com.github.seregamorph.testsmartcontext.demo;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@EnableAutoConfiguration
+@ContextConfiguration(classes = {
+    WebIntegrationTest.Configuration.class
+})
+@ActiveProfiles("test")
+@TestPropertySource(properties = {
+    "parameter = value"
+})
+public class WebIntegrationTest extends AbstractIntegrationTest {
+
+    @Autowired
+    private TestRestTemplate testRestTemplate;
+
+    @Test
+    public void test404() {
+        var entity = testRestTemplate.getForEntity("/article", String.class);
+        assertEquals(404, entity.getStatusCode().value());
+    }
+
+    public static class Configuration {
+
+    }
+}

--- a/demo/demo-testkit/src/main/java/com/github/seregamorph/testsmartcontext/testkit/TestContextEventTrackerListener.java
+++ b/demo/demo-testkit/src/main/java/com/github/seregamorph/testsmartcontext/testkit/TestContextEventTrackerListener.java
@@ -15,18 +15,21 @@ public class TestContextEventTrackerListener extends SpringContextEventLoggerLis
     @Override
     protected void onContextRefreshedEvent(ContextRefreshedEvent event) {
         super.onContextRefreshedEvent(event);
-        TestEventTracker.trackEvent("Created context for " + CurrentTestContext.getCurrentTestClassName());
+        boolean isChild = event.getApplicationContext().getParent() != null;
+        TestEventTracker.trackEvent("Created " + (isChild ? "child context" : "context") + " for "
+            + CurrentTestContext.getCurrentTestClassName());
     }
 
     @Override
     protected void onContextClosedEvent(ContextClosedEvent event) {
         String currentTestClass = CurrentTestContext.getCurrentTestClassName();
+        boolean isChild = event.getApplicationContext().getParent() != null;
         if (currentTestClass == null) {
             // system shutdown hook
-            TestEventTracker.trackEvent("Destroying context (hook)");
+            TestEventTracker.trackEvent("Destroying " + (isChild ? "child context" : "context") + " (hook)");
         } else {
             // triggered via SmartDirtiesContextTestExecutionListener or spring DirtiesContextTestExecutionListener
-            TestEventTracker.trackEvent("Destroying context for " + currentTestClass);
+            TestEventTracker.trackEvent("Destroying " + (isChild ? "child context" : "context") + " for " + currentTestClass);
         }
     }
 }

--- a/spring-test-smart-context/src/main/java/com/github/seregamorph/testsmartcontext/SpringContextEventLoggerListener.java
+++ b/spring-test-smart-context/src/main/java/com/github/seregamorph/testsmartcontext/SpringContextEventLoggerListener.java
@@ -48,17 +48,20 @@ public class SpringContextEventLoggerListener implements ApplicationListener<App
     protected void onContextRefreshedEvent(ContextRefreshedEvent event) {
         long nowNanos = System.nanoTime();
         String contextInitFormatted = formatNanos(nowNanos - createdNanos);
-        logger.info("Created context in {} for {}", contextInitFormatted, CurrentTestContext.getCurrentTestClassName());
+        boolean isChild = event.getApplicationContext().getParent() != null;
+        logger.info("Created {} in {} for {}",
+            isChild ? "child context" : "context", contextInitFormatted, CurrentTestContext.getCurrentTestClassName());
     }
 
     protected void onContextClosedEvent(ContextClosedEvent event) {
         String testClassIdentifier = CurrentTestContext.getCurrentTestClassName();
+        boolean isChild = event.getApplicationContext().getParent() != null;
         if (testClassIdentifier == null) {
             // system shutdown hook
-            logger.info("Destroying context (hook)");
+            logger.info("Destroying {} (hook)", isChild ? "child context" : "context");
         } else {
             // triggered via SmartDirtiesContextTestExecutionListener or spring DirtiesContextTestExecutionListener
-            logger.info("Destroying context for {}", testClassIdentifier);
+            logger.info("Destroying {} for {}", isChild ? "child context" : "context", testClassIdentifier);
         }
     }
 


### PR DESCRIPTION
In case if spring creates more than one context (e.g. for actuator), it can be a bit confusing to see duplicated log messages like

```
2025-03-24 12:49:04.750  INFO [    Test worker] c.g.s.t.SpringContextEventLoggerListener : Created context in 9.220s for com.acme.appsettingsservice.AppSettingsServiceTest
2025-03-24 12:49:04.750  INFO [    Test worker] c.g.s.t.SpringContextEventLoggerListener : Created context in 9.220s for com.acme.appsettingsservice.AppSettingsServiceTest
...
2025-03-24 12:49:08.198  INFO [    Test worker] c.g.s.t.SpringContextEventLoggerListener : Destroying context for com.acme.appsettingsservice.AppSettingsServiceTest
2025-03-24 12:49:08.198  INFO [    Test worker] c.g.s.t.SpringContextEventLoggerListener : Destroying context for com.acme.appsettingsservice.AppSettingsServiceTest
```

In the updated implementation the root and child contexts are distinguished. E.g.:
```
2025-03-24 12:49:08.198  INFO [    Test worker] c.g.s.t.SpringContextEventLoggerListener : Destroying context for com.acme.appsettingsservice.AppSettingsServiceTest
2025-03-24 12:49:08.199  INFO [    Test worker] c.g.s.t.SpringContextEventLoggerListener : Destroying child context for com.acme.appsettingsservice.AppSettingsServiceTest
```