### PR TITLE
Print suite size

### DIFF
--- a/spring-test-smart-context/src/main/java/com/github/seregamorph/testsmartcontext/SmartDirtiesTestsSorter.java
+++ b/spring-test-smart-context/src/main/java/com/github/seregamorph/testsmartcontext/SmartDirtiesTestsSorter.java
@@ -111,7 +111,7 @@ public class SmartDirtiesTestsSorter {
             .collect(Collectors.toList());
 
         if (!sortedConfigToTests.isEmpty()) {
-            printSuiteTestsPerConfig(itClasses.size(), sortedConfigToTests);
+            printSuiteTestsPerConfig(testItems.size(), itClasses.size(), sortedConfigToTests);
         }
 
         return sortedConfigToTests;
@@ -165,10 +165,11 @@ public class SmartDirtiesTestsSorter {
         logger.debug(sw.toString());
     }
 
-    private void printSuiteTestsPerConfig(int itClassesSize, List<List<Class<?>>> sortedConfigToTests) {
+    private void printSuiteTestsPerConfig(int totalTests, int itClassesSize, List<List<Class<?>>> sortedConfigToTests) {
         StringWriter sw = new StringWriter();
         PrintWriter pw = new PrintWriter(sw, true);
-        pw.println(itClassesSize + " integration test classes grouped and reordered by MergedContextConfiguration "
+        pw.println("Running suite of " + totalTests + " tests. "
+            + itClassesSize + " integration test classes grouped and reordered by MergedContextConfiguration "
             + "(" + sortedConfigToTests.size() + " groups):");
         sortedConfigToTests.forEach(itClasses -> {
             pw.println("---");


### PR DESCRIPTION
Enhanced logging. To avoid confusion print the full size of test suite:
```
09:38:34 [main] INFO  com.github.seregamorph.testsmartcontext.SmartDirtiesTestsSorter - Running suite of 4 tests. 3 integration test classes grouped and reordered by MergedContextConfiguration (2 groups):
---
com.github.seregamorph.testsmartcontext.demo.Integration1SecondTest (creates context; marked @DirtiesContext(BEFORE_CLASS))
com.github.seregamorph.testsmartcontext.demo.Integration1Test (closes context)
---
com.github.seregamorph.testsmartcontext.demo.Integration2Test (creates and closes context)
```