### PR TITLE
Support Parallel Test Execution

### DIFF
--- a/spring-test-smart-context/src/main/java/com/github/seregamorph/testsmartcontext/SmartDirtiesContextTestExecutionListener.java
+++ b/spring-test-smart-context/src/main/java/com/github/seregamorph/testsmartcontext/SmartDirtiesContextTestExecutionListener.java
@@ -52,7 +52,7 @@ public class SmartDirtiesContextTestExecutionListener extends AbstractTestExecut
         currentAutoClosingContext.set(true);
         try {
             Class<?> testClass = testContext.getTestClass();
-            if (SmartDirtiesTestsSupport.isLastClassPerConfig(testClass)) {
+            if (SmartDirtiesTestsSupport.markCompleteAndIsLastClassPerConfig(testClass)) {
                 if (testContext.hasApplicationContext()) {
                     logger.info("Auto-closing context after {}", testClass.getName());
                     testContext.markApplicationContextDirty(null);

--- a/spring-test-smart-context/src/main/java/com/github/seregamorph/testsmartcontext/SmartDirtiesTestsSupport.java
+++ b/spring-test-smart-context/src/main/java/com/github/seregamorph/testsmartcontext/SmartDirtiesTestsSupport.java
@@ -8,8 +8,8 @@ import java.lang.reflect.Modifier;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -35,30 +35,28 @@ public class SmartDirtiesTestsSupport {
     protected static final String ENGINE_JUNIT_JUPITER = "junit-jupiter";
 
     /**
-     * engine -> test class -> ClassOrderState
+     * engine -> test class -> ClassGroupState
      */
-    private static Map<String, Map<Class<?>, ClassOrderState>> engineClassOrderStateMap;
+    private static Map<String, Map<Class<?>, ClassGroupState>> engineClassOrderStateMap;
 
     @Nullable
     private static Throwable failureCause;
 
-    static class ClassOrderState {
-        final boolean isIntegrationTest;
-        final String testEngine;
-        final boolean isFirst;
-        final boolean isLast;
+    static class ClassGroupState {
+        private final Set<Class<?>> completedItClasses = Collections.synchronizedSet(new LinkedHashSet<>());
 
-        private ClassOrderState(boolean isIntegrationTest, String testEngine, boolean isFirst, boolean isLast) {
-            this.isIntegrationTest = isIntegrationTest;
-            this.testEngine = testEngine;
-            this.isFirst = isFirst;
-            this.isLast = isLast;
+        private final String engine;
+        final Set<Class<?>> discoveredItClasses;
+
+        private ClassGroupState(String engine, List<Class<?>> discoveredItClasses) {
+            this.engine = engine;
+            this.discoveredItClasses = Collections.unmodifiableSet(new LinkedHashSet<>(discoveredItClasses));
         }
     }
 
     @Nullable
     static Set<Class<?>> getTestClasses(String engine) {
-        Map<Class<?>, ClassOrderState> classOrderStateMap = engineClassOrderStateMap == null ? null
+        Map<Class<?>, ClassGroupState> classOrderStateMap = engineClassOrderStateMap == null ? null
             : engineClassOrderStateMap.get(engine);
         return classOrderStateMap == null ? null : classOrderStateMap.keySet();
     }
@@ -68,24 +66,24 @@ public class SmartDirtiesTestsSupport {
         return testClasses == null ? 0 : testClasses.size();
     }
 
-    static boolean isLastClassPerConfig(Class<?> testClass) {
+    static boolean markCompleteAndIsLastClassPerConfig(Class<?> testClass) {
         if (isInnerClass(testClass)) {
             // to support @Nested classes (without own context configuration)
             return false;
         }
 
-        List<ClassOrderState> classOrderStates = getOrderStates(testClass);
-        for (ClassOrderState classOrderState : classOrderStates) {
-            if (!classOrderState.isIntegrationTest) {
+        List<ClassGroupState> classGroupStates = getOrderStates(testClass);
+        for (ClassGroupState classGroupState : classGroupStates) {
+            if (!classGroupState.discoveredItClasses.contains(testClass)) {
                 // This can be a result of custom extension or listener.
                 // To fix this implement own IntegrationTestFilter and declare via META-INF SPI
                 log.warn("Test {} in suite of {} engine was not recognized as spring integration test by {}, "
                         + "it's recommended to override the IntegrationTestFilter accordingly",
-                    testClass, classOrderState.testEngine, IntegrationTestFilter.getInstance().getClass());
+                    testClass, classGroupState.engine, IntegrationTestFilter.getInstance().getClass());
             }
         }
 
-        if (classOrderStates.isEmpty()) {
+        if (classGroupStates.isEmpty()) {
             List<String> classes = engineClassOrderStateMap.entrySet().stream()
                 .map(entry -> {
                     String engineClassNames = entry.getValue().keySet().stream()
@@ -98,14 +96,19 @@ public class SmartDirtiesTestsSupport {
                 + testClass + ", it means that it was skipped on initial analysis or failed. "
                 + "Discovered classes by engine: " + classes + (failureCause == null ? "" : ": " + failureCause),
                 failureCause);
-        } else if (classOrderStates.size() == 1) {
-            return classOrderStates.get(0).isLast;
+        } else if (classGroupStates.size() == 1) {
+            ClassGroupState classGroupState = classGroupStates.get(0);
+            classGroupState.completedItClasses.add(testClass);
+            return classGroupState.discoveredItClasses.equals(classGroupState.completedItClasses);
         } else {
             // In the common case it's theoretically possible that the same class is discovered by more than one
             // test engine. And at this point we don't know which engine is running current test,
             // so we do a failover logic
-            Set<Boolean> isLasts = classOrderStates.stream()
-                .map(state -> state.isLast)
+            Set<Boolean> isLasts = classGroupStates.stream()
+                .map(classGroupState -> {
+                    classGroupState.completedItClasses.add(testClass);
+                    return classGroupState.discoveredItClasses.equals(classGroupState.completedItClasses);
+                })
                 .collect(Collectors.toSet());
 
             if (isLasts.size() == 1) {
@@ -114,8 +117,8 @@ public class SmartDirtiesTestsSupport {
             } else {
                 assert isLasts.size() == 2;
                 log.warn("Test {} was discovered by more than one test engine with different ordering {}", testClass,
-                    classOrderStates.stream()
-                        .map(state -> state.testEngine)
+                    classGroupStates.stream()
+                        .map(state -> state.engine)
                         .collect(Collectors.toList()));
                 // at least one engine considers it as last: do close the context
                 return true;
@@ -123,7 +126,7 @@ public class SmartDirtiesTestsSupport {
         }
     }
 
-    static List<ClassOrderState> getOrderStates(Class<?> testClass) {
+    static List<ClassGroupState> getOrderStates(Class<?> testClass) {
         if (engineClassOrderStateMap == null) {
             if (failureCause != null) {
                 throw new IllegalStateException("Test ordering is not initialized or failed", failureCause);
@@ -184,32 +187,26 @@ public class SmartDirtiesTestsSupport {
             throw new IllegalStateException("Test ordering is not initialized or failed");
         }
 
-        List<ClassOrderState> classOrderStates = new ArrayList<>();
-        for (Map<Class<?>, ClassOrderState> classOrderStateMap : engineClassOrderStateMap.values()) {
-            ClassOrderState classOrderState = classOrderStateMap.get(testClass);
-            if (classOrderState != null) {
-                classOrderStates.add(classOrderState);
+        List<ClassGroupState> classGroupStates = new ArrayList<>();
+        for (Map<Class<?>, ClassGroupState> classOrderStateMap : engineClassOrderStateMap.values()) {
+            ClassGroupState classGroupState = classOrderStateMap.get(testClass);
+            if (classGroupState != null) {
+                classGroupStates.add(classGroupState);
             }
         }
-        return classOrderStates;
+        return classGroupStates;
     }
 
     protected static void setTestClassesLists(String engine, TestSortResult testSortResult) {
-        Map<Class<?>, ClassOrderState> classOrderStateMap = new LinkedHashMap<>();
+        Map<Class<?>, ClassGroupState> classOrderStateMap = new LinkedHashMap<>();
         for (List<Class<?>> testClasses : testSortResult.getSortedConfigToTests()) {
-            Iterator<Class<?>> iterator = testClasses.iterator();
-            boolean isFirst = true;
-            while (iterator.hasNext()) {
-                Class<?> testClass = iterator.next();
-                classOrderStateMap.put(testClass,
-                    new ClassOrderState(true, engine, isFirst, !iterator.hasNext()));
-                isFirst = false;
+            ClassGroupState classGroupState = new ClassGroupState(engine, testClasses);
+            for (Class<?> testClass : testClasses) {
+                classOrderStateMap.put(testClass, classGroupState);
             }
         }
         for (Class<?> nonItClass : testSortResult.getNonItClasses()) {
-            ClassOrderState prev = classOrderStateMap.put(nonItClass,
-                new ClassOrderState(false, engine, false, false));
-            assert prev == null;
+            classOrderStateMap.put(nonItClass, new ClassGroupState(engine, Collections.emptyList()));
         }
 
         if (SmartDirtiesTestsSupport.engineClassOrderStateMap == null) {
@@ -258,10 +255,10 @@ public class SmartDirtiesTestsSupport {
     }
 
     //@TestOnly
-    static Map<String, Map<Class<?>, ClassOrderState>> setEngineClassOrderStateMap(
-        Map<String, Map<Class<?>, ClassOrderState>> engineClassOrderStateMap
+    static Map<String, Map<Class<?>, ClassGroupState>> setEngineClassOrderStateMap(
+        Map<String, Map<Class<?>, ClassGroupState>> engineClassOrderStateMap
     ) {
-        Map<String, Map<Class<?>, ClassOrderState>> prev = SmartDirtiesTestsSupport.engineClassOrderStateMap;
+        Map<String, Map<Class<?>, ClassGroupState>> prev = SmartDirtiesTestsSupport.engineClassOrderStateMap;
         SmartDirtiesTestsSupport.engineClassOrderStateMap = engineClassOrderStateMap;
         return prev;
     }

--- a/tests/tests-gradle-junit-platform-jupiter-boot32/src/test/java/com/github/seregamorph/testsmartcontext/GradleSmartDirtiesJupiterEngineTest.java
+++ b/tests/tests-gradle-junit-platform-jupiter-boot32/src/test/java/com/github/seregamorph/testsmartcontext/GradleSmartDirtiesJupiterEngineTest.java
@@ -25,7 +25,7 @@ public class GradleSmartDirtiesJupiterEngineTest {
 
     private static final String ENGINE = "junit-jupiter";
 
-    private static Map<String, Map<Class<?>, SmartDirtiesTestsSupport.ClassOrderState>> prevEngineClassOrderStateMap;
+    private static Map<String, Map<Class<?>, SmartDirtiesTestsSupport.ClassGroupState>> prevEngineClassOrderStateMap;
 
     @BeforeAll
     public static void beforeClass() {

--- a/tests/tests-maven-junit-platform-junit4-boot24/src/test/java/com/github/seregamorph/testsmartcontext/MavenSmartDirtiesVintageEngineTest.java
+++ b/tests/tests-maven-junit-platform-junit4-boot24/src/test/java/com/github/seregamorph/testsmartcontext/MavenSmartDirtiesVintageEngineTest.java
@@ -21,7 +21,7 @@ public class MavenSmartDirtiesVintageEngineTest {
 
     private static final String ENGINE = "junit-vintage";
 
-    private static Map<String, Map<Class<?>, SmartDirtiesTestsSupport.ClassOrderState>> prevEngineClassOrderStateMap;
+    private static Map<String, Map<Class<?>, SmartDirtiesTestsSupport.ClassGroupState>> prevEngineClassOrderStateMap;
 
     @BeforeClass
     public static void beforeClass() {

--- a/tests/tests-maven-junit-platform-jupiter-boot35/src/test/java/com/github/seregamorph/testsmartcontext/MavenSmartDirtiesJupiterEngineTest.java
+++ b/tests/tests-maven-junit-platform-jupiter-boot35/src/test/java/com/github/seregamorph/testsmartcontext/MavenSmartDirtiesJupiterEngineTest.java
@@ -30,7 +30,7 @@ public class MavenSmartDirtiesJupiterEngineTest {
 
     private static final String ENGINE = "junit-jupiter";
 
-    private static Map<String, Map<Class<?>, SmartDirtiesTestsSupport.ClassOrderState>> prevEngineClassOrderStateMap;
+    private static Map<String, Map<Class<?>, SmartDirtiesTestsSupport.ClassGroupState>> prevEngineClassOrderStateMap;
 
     @BeforeAll
     public static void beforeClass() {

--- a/tests/tests-maven-junit-platform-jupiter-boot40/src/test/java/com/github/seregamorph/testsmartcontext/MavenSmartDirtiesJupiterEngineTest.java
+++ b/tests/tests-maven-junit-platform-jupiter-boot40/src/test/java/com/github/seregamorph/testsmartcontext/MavenSmartDirtiesJupiterEngineTest.java
@@ -30,7 +30,7 @@ public class MavenSmartDirtiesJupiterEngineTest {
 
     private static final String ENGINE = "junit-jupiter";
 
-    private static Map<String, Map<Class<?>, SmartDirtiesTestsSupport.ClassOrderState>> prevEngineClassOrderStateMap;
+    private static Map<String, Map<Class<?>, SmartDirtiesTestsSupport.ClassGroupState>> prevEngineClassOrderStateMap;
 
     @BeforeAll
     public static void beforeClass() {

--- a/tests/tests-maven-junit-platform-jupiter-spring5/src/test/java/com/github/seregamorph/testsmartcontext/MavenSmartDirtiesJupiterEngineTest.java
+++ b/tests/tests-maven-junit-platform-jupiter-spring5/src/test/java/com/github/seregamorph/testsmartcontext/MavenSmartDirtiesJupiterEngineTest.java
@@ -24,7 +24,7 @@ public class MavenSmartDirtiesJupiterEngineTest {
 
     private static final String ENGINE = "junit-jupiter";
 
-    private static Map<String, Map<Class<?>, SmartDirtiesTestsSupport.ClassOrderState>> prevEngineClassOrderStateMap;
+    private static Map<String, Map<Class<?>, SmartDirtiesTestsSupport.ClassGroupState>> prevEngineClassOrderStateMap;
 
     @BeforeAll
     public static void beforeClass() {

--- a/tests/tests-maven-junit-platform-jupiter-spring7/src/test/java/com/github/seregamorph/testsmartcontext/MavenSmartDirtiesJupiterEngineTest.java
+++ b/tests/tests-maven-junit-platform-jupiter-spring7/src/test/java/com/github/seregamorph/testsmartcontext/MavenSmartDirtiesJupiterEngineTest.java
@@ -24,7 +24,7 @@ public class MavenSmartDirtiesJupiterEngineTest {
 
     private static final String ENGINE = "junit-jupiter";
 
-    private static Map<String, Map<Class<?>, SmartDirtiesTestsSupport.ClassOrderState>> prevEngineClassOrderStateMap;
+    private static Map<String, Map<Class<?>, SmartDirtiesTestsSupport.ClassGroupState>> prevEngineClassOrderStateMap;
 
     @BeforeAll
     public static void beforeClass() {

--- a/tests/tests-maven-junit-platform-mixed-boot34/src/test/java/com/github/seregamorph/testsmartcontext/MavenSmartDirtiesJupiterEngineTest.java
+++ b/tests/tests-maven-junit-platform-mixed-boot34/src/test/java/com/github/seregamorph/testsmartcontext/MavenSmartDirtiesJupiterEngineTest.java
@@ -25,7 +25,7 @@ public class MavenSmartDirtiesJupiterEngineTest {
 
     private static final String ENGINE = "junit-jupiter";
 
-    private static Map<String, Map<Class<?>, SmartDirtiesTestsSupport.ClassOrderState>> prevEngineClassOrderStateMap;
+    private static Map<String, Map<Class<?>, SmartDirtiesTestsSupport.ClassGroupState>> prevEngineClassOrderStateMap;
 
     @BeforeAll
     public static void beforeClass() {

--- a/tests/tests-maven-junit-platform-mixed-boot34/src/test/java/com/github/seregamorph/testsmartcontext/MavenSmartDirtiesTestngEngineTest.java
+++ b/tests/tests-maven-junit-platform-mixed-boot34/src/test/java/com/github/seregamorph/testsmartcontext/MavenSmartDirtiesTestngEngineTest.java
@@ -20,7 +20,7 @@ public class MavenSmartDirtiesTestngEngineTest {
 
     private static final String ENGINE = "testng";
 
-    private static Map<String, Map<Class<?>, SmartDirtiesTestsSupport.ClassOrderState>> prevEngineClassOrderStateMap;
+    private static Map<String, Map<Class<?>, SmartDirtiesTestsSupport.ClassGroupState>> prevEngineClassOrderStateMap;
 
     @BeforeAll
     public static void beforeClass() {

--- a/tests/tests-maven-junit-platform-mixed-boot34/src/test/java/com/github/seregamorph/testsmartcontext/MavenSmartDirtiesVintageEngineTest.java
+++ b/tests/tests-maven-junit-platform-mixed-boot34/src/test/java/com/github/seregamorph/testsmartcontext/MavenSmartDirtiesVintageEngineTest.java
@@ -20,7 +20,7 @@ public class MavenSmartDirtiesVintageEngineTest {
 
     private static final String ENGINE = "junit-vintage";
 
-    private static Map<String, Map<Class<?>, SmartDirtiesTestsSupport.ClassOrderState>> prevEngineClassOrderStateMap;
+    private static Map<String, Map<Class<?>, SmartDirtiesTestsSupport.ClassGroupState>> prevEngineClassOrderStateMap;
 
     @BeforeAll
     public static void beforeClass() {

--- a/tests/tests-maven-junit-platform-testng-boot32/src/test/java/com/github/seregamorph/testsmartcontext/SmartDirtiesTestngEngineTest.java
+++ b/tests/tests-maven-junit-platform-testng-boot32/src/test/java/com/github/seregamorph/testsmartcontext/SmartDirtiesTestngEngineTest.java
@@ -23,7 +23,7 @@ public class SmartDirtiesTestngEngineTest {
 
     private static final String ENGINE = "testng";
 
-    private static Map<String, Map<Class<?>, SmartDirtiesTestsSupport.ClassOrderState>> prevEngineClassOrderStateMap;
+    private static Map<String, Map<Class<?>, SmartDirtiesTestsSupport.ClassGroupState>> prevEngineClassOrderStateMap;
 
     @BeforeClass
     public static void beforeClass() {

--- a/tests/tests-maven-testng-boot24/pom.xml
+++ b/tests/tests-maven-testng-boot24/pom.xml
@@ -24,6 +24,11 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <suiteXmlFiles>
+                        <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>
+                    </suiteXmlFiles>
+                </configuration>
                 <dependencies>
                     <dependency>
                         <groupId>org.apache.maven.surefire</groupId>

--- a/tests/tests-maven-testng-boot24/src/test/java/com/github/seregamorph/testsmartcontext/demo/Integration1SecondTest.java
+++ b/tests/tests-maven-testng-boot24/src/test/java/com/github/seregamorph/testsmartcontext/demo/Integration1SecondTest.java
@@ -1,9 +1,11 @@
 package com.github.seregamorph.testsmartcontext.demo;
 
 import static org.springframework.test.annotation.DirtiesContext.ClassMode.BEFORE_CLASS;
+import static org.testng.Assert.assertTrue;
 
 import com.github.seregamorph.testsmartcontext.testkit.TestEventTracker;
 import com.github.seregamorph.testsmartcontext.testng.AbstractTestNGSpringIntegrationTest;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.testng.annotations.Test;
@@ -15,7 +17,9 @@ import org.testng.annotations.Test;
 public class Integration1SecondTest extends AbstractTestNGSpringIntegrationTest {
 
     @Test
-    public void test() {
+    public void test() throws Exception {
+        Thread.sleep(1500L);
         TestEventTracker.trackEvent("Running " + getClass().getSimpleName());
+        assertTrue(((ConfigurableApplicationContext) applicationContext).isActive(), "Context should be active");
     }
 }

--- a/tests/tests-maven-testng-boot24/src/test/java/com/github/seregamorph/testsmartcontext/demo/Integration1Test.java
+++ b/tests/tests-maven-testng-boot24/src/test/java/com/github/seregamorph/testsmartcontext/demo/Integration1Test.java
@@ -2,9 +2,12 @@ package com.github.seregamorph.testsmartcontext.demo;
 
 import com.github.seregamorph.testsmartcontext.testkit.TestEventTracker;
 import com.github.seregamorph.testsmartcontext.testng.AbstractTestNGSpringIntegrationTest;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.ContextConfiguration;
 import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertTrue;
 
 @ContextConfiguration(classes = {
     Integration1Test.Configuration.class
@@ -14,6 +17,7 @@ public class Integration1Test extends AbstractTestNGSpringIntegrationTest {
     @Test
     public void test() {
         TestEventTracker.trackEvent("Running " + getClass().getSimpleName());
+        assertTrue(((ConfigurableApplicationContext) applicationContext).isActive(), "Context should be active");
     }
 
     public static class Configuration {

--- a/tests/tests-maven-testng-boot24/src/test/java/com/github/seregamorph/testsmartcontext/demo/MavenTestngTest.java
+++ b/tests/tests-maven-testng-boot24/src/test/java/com/github/seregamorph/testsmartcontext/demo/MavenTestngTest.java
@@ -1,4 +1,4 @@
-package com.github.seregamorph.testsmartcontext;
+package com.github.seregamorph.testsmartcontext.demo;
 
 import com.github.seregamorph.testsmartcontext.testkit.TestEventTracker;
 import org.testng.annotations.AfterSuite;

--- a/tests/tests-maven-testng-boot24/src/test/resources/testng.xml
+++ b/tests/tests-maven-testng-boot24/src/test/resources/testng.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
+<suite name="All Test Suite" parallel="classes" thread-count="1">
+    <test name="Tests">
+        <packages>
+            <package name="com.github.seregamorph.testsmartcontext.demo"/>
+        </packages>
+    </test>
+</suite>

--- a/tests/tests-testkit/src/main/java/com/github/seregamorph/testsmartcontext/SmartDirtiesTestKitSupport.java
+++ b/tests/tests-testkit/src/main/java/com/github/seregamorph/testsmartcontext/SmartDirtiesTestKitSupport.java
@@ -11,21 +11,42 @@ public final class SmartDirtiesTestKitSupport {
         }
 
         // this method is only used in tests, so we don't need to be lenient there
-        List<SmartDirtiesTestsSupport.ClassOrderState> classOrderStates =
+        List<SmartDirtiesTestsSupport.ClassGroupState> classGroupStates =
             SmartDirtiesTestsSupport.getOrderStates(testClass);
-        if (classOrderStates.size() == 1) {
-            SmartDirtiesTestsSupport.ClassOrderState classOrderState = classOrderStates.get(0);
-            if (!classOrderState.isIntegrationTest) {
+        if (classGroupStates.size() == 1) {
+            SmartDirtiesTestsSupport.ClassGroupState classGroupState = classGroupStates.get(0);
+            if (!classGroupState.discoveredItClasses.contains(testClass)) {
                 throw new IllegalStateException("Test " + testClass + " is not recognized as integration test");
             }
-            return classOrderState.isFirst;
+            return classGroupState.discoveredItClasses.iterator().next() == testClass;
         } else {
             throw new IllegalStateException("Unexpected more than one matching test engine for " + testClass);
         }
     }
 
+
     static boolean isLastClassPerConfig(Class<?> testClass) {
-        return SmartDirtiesTestsSupport.isLastClassPerConfig(testClass);
+        if (SmartDirtiesTestsSupport.isInnerClass(testClass)) {
+            // to support @Nested classes (without own context configuration)
+            return false;
+        }
+
+        // this method is only used in tests, so we don't need to be lenient there
+        List<SmartDirtiesTestsSupport.ClassGroupState> classGroupStates =
+            SmartDirtiesTestsSupport.getOrderStates(testClass);
+        if (classGroupStates.size() == 1) {
+            SmartDirtiesTestsSupport.ClassGroupState classGroupState = classGroupStates.get(0);
+            if (!classGroupState.discoveredItClasses.contains(testClass)) {
+                throw new IllegalStateException("Test " + testClass + " is not recognized as integration test");
+            }
+            Class<?> lastClass = null;
+            for (Class<?> discoveredItClass : classGroupState.discoveredItClasses) {
+                lastClass = discoveredItClass;
+            }
+            return lastClass == testClass;
+        } else {
+            throw new IllegalStateException("Unexpected more than one matching test engine for " + testClass);
+        }
     }
 
     private SmartDirtiesTestKitSupport() {


### PR DESCRIPTION
Support TestNG and JUnit Jupiter parallel test execution

Special notes:
`org.springframework.test.context.cache.DefaultCacheAwareContextLoaderDelegate.loadContext(MergedContextConfiguration)`, the method responsible for creating spring context for the given `MergedContextConfiguration` is `synchronized`, so there is no risk that there will be more than one active context per configuration.

But the number of active contexts is now not more than the number of test worker threads.